### PR TITLE
Based on md5s3stash - md5s3stash for exhibitapp works with the local filesystem and boto3

### DIFF
--- a/env.local.in
+++ b/env.local.in
@@ -1,5 +1,0 @@
-export EXHIBIT_PREVIEW = True
-export UCLDC_THUMBNAIL_URL='https://calisphere.org/'            # or pillbox md5s3stash/thumbnail.py
-export UCLDC_SOLR_URL=http://localhost:8983/solr                # solr
-export UCLDC_SOLR_API_KEY=                                      # contact ucldc@ucop.edu
-export UCLDC_EXHIBIT_PREVIEW=True

--- a/exhibits/md5s3stash.py
+++ b/exhibits/md5s3stash.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+""" md5s3stash
+    content addressable storage in AWS S3
+"""
+import urllib.parse
+import logging
+import hashlib
+import boto3
+from botocore.errorfactory import ClientError
+import magic
+from PIL import Image
+from collections import namedtuple
+
+
+def md5s3stash(file_path, bucket_base):
+    """ stash a file at `file_path` in the named `bucket_base` """
+    StashReport = namedtuple(
+        'StashReport', 'url, md5, s3_url, mime_type, dimensions')
+    md5 = hashChunks(file_path)
+    s3_url = "s3://{0}/{1}".format(bucket_base,md5)
+    (mime, dimensions) = image_info(file_path)
+    s3move(file_path, s3_url, mime)
+    report = StashReport(file_path, md5, s3_url, mime, dimensions)
+    logging.getLogger('MD5S3:stash').info(report)
+    return report
+
+
+def hashChunks(file_path):
+    """
+       Helper to return an md5 checksum
+
+       based on downloadChunks@https://gist.github.com/gourneau/1430932
+       and http://www.pythoncentral.io/hashing-files-with-python/
+    """
+    hasher = hashlib.new('md5')
+    BLOCKSIZE = 1024 * hasher.block_size
+    try:
+        with open(file_path, 'r') as file:
+            while True:
+                chunk = file.read(BLOCKSIZE)
+                hasher.update(chunk)
+                if not chunk:
+                    break
+    except IOError as e:
+        print("Could not open file", e, file_path)
+        return False
+
+    md5 = hasher.hexdigest()
+    return md5
+
+
+def s3move(file_path, s3_url, mime):
+    s3 = boto3.client('s3')
+    l = logging.getLogger('MD5S3:s3move')
+    l.debug({
+        'file_path': file_path,
+        's3_url': s3_url,
+        'mime': mime,
+        's3': s3
+    })
+    parts = urllib.parse.urlsplit(s3_url)
+    try:
+        s3.head_object(Bucket=parts.netloc, Key=parts.path[1:])
+        l.info('key existed already')
+    except ClientError:
+        public_read = 'uri="http://acs.amazonaws.com/groups/global/AllUsers"'
+        s3.upload_file(file_path, parts.netloc, parts.path[1:], 
+            ExtraArgs={
+                'GrantRead': public_read, 
+                'GrantFullControl': settings.S3_ID, 
+                'ContentType': mime
+            })
+        l.debug('file sent to s3')
+
+def image_info(filepath):
+    ''' get image info
+        `filepath` path to a file
+        returns
+          a tuple of two values
+            1. mime/type if an image; otherwise None
+            2. a tuple of (height, width) if an image; otherwise (0,0)
+    '''
+    try:
+        return (
+            magic.Magic(mime=True).from_file(filepath),
+            Image.open(filepath).size
+        )
+    except IOError as e:
+        if not e.message.startswith('cannot identify image file'):
+            raise e
+        else:
+            return (None, (0,0))
+
+

--- a/exhibits/md5s3stash.py
+++ b/exhibits/md5s3stash.py
@@ -35,7 +35,7 @@ def hashChunks(file_path):
     hasher = hashlib.new('md5')
     BLOCKSIZE = 1024 * hasher.block_size
     try:
-        with open(file_path, 'r') as file:
+        with open(file_path, 'rb') as file:
             while True:
                 chunk = file.read(BLOCKSIZE)
                 hasher.update(chunk)

--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -217,7 +217,7 @@ class Exhibit(models.Model):
                 url = settings.MEDIA_ROOT + "/" + name
                 if os.path.isfile(url):
                     field_instance = getattr(self, s3field)
-                    report = md5s3stash("file://" + url, settings.S3_STASH, settings.S3_ID)
+                    report = md5s3stash(url, settings.S3_STASH, settings.S3_ID)
                     field_instance.storage.delete(name)
                     field_instance.name = report.md5
                     upload_to = self._meta.get_field(s3field).upload_to
@@ -288,7 +288,7 @@ class HistoricalEssay(models.Model):
                 url = settings.MEDIA_ROOT + "/" + name
                 if os.path.isfile(url):
                     field_instance = getattr(self, s3field)
-                    report = md5s3stash("file://" + url, settings.S3_STASH, settings.S3_ID)
+                    report = md5s3stash(url, settings.S3_STASH, settings.S3_ID)
                     field_instance.storage.delete(name)
                     field_instance.name = report.md5
                     upload_to = self._meta.get_field(s3field).upload_to
@@ -408,7 +408,7 @@ class LessonPlan(models.Model):
                 url = settings.MEDIA_ROOT + "/" + name
                 if os.path.isfile(url):
                     field_instance = getattr(self, s3field)
-                    report = md5s3stash("file://" + url, settings.S3_STASH, settings.S3_ID)
+                    report = md5s3stash(url, settings.S3_STASH, settings.S3_ID)
                     field_instance.storage.delete(name)
                     field_instance.name = report.md5
                     upload_to = self._meta.get_field(s3field).upload_to
@@ -505,7 +505,7 @@ class Theme(models.Model):
                 url = settings.MEDIA_ROOT + "/" + name
                 if os.path.isfile(url):
                     field_instance = getattr(self, s3field)
-                    report = md5s3stash("file://" + url, settings.S3_STASH, settings.S3_ID)
+                    report = md5s3stash(url, settings.S3_STASH, settings.S3_ID)
                     field_instance.storage.delete(name)
                     field_instance.name = report.md5
                     upload_to = self._meta.get_field(s3field).upload_to
@@ -608,7 +608,7 @@ class ExhibitItem(models.Model):
                 url = settings.MEDIA_ROOT + "/" + name
                 if os.path.isfile(url):
                     field_instance = getattr(self, s3field)
-                    report = md5s3stash("file://" + url, settings.S3_STASH, settings.S3_ID)
+                    report = md5s3stash(url, settings.S3_STASH, settings.S3_ID)
                     field_instance.storage.delete(name)
                     field_instance.name = report.md5
                     upload_to = self._meta.get_field(s3field).upload_to

--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -9,8 +9,7 @@ from django.urls import reverse
 from django.utils.encoding import python_2_unicode_compatible
 from django.conf import settings
 from exhibits.custom_fields import HeroField
-from past import autotranslate
-from md5s3stash import md5s3stash
+from exhibits.md5s3stash import md5s3stash
 
 try:
     from calisphere.cache_retry import SOLR_select

--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -219,11 +219,7 @@ class Exhibit(models.Model):
                 url = settings.MEDIA_ROOT + "/" + name
                 if os.path.isfile(url):
                     field_instance = getattr(self, s3field)
-                    if settings.S3_STASH_ACL:
-                        acl=settings.S3_STASH_ACL
-                    else:
-                        acl=None
-                    report = md5s3stash("file://" + url, settings.S3_STASH, acl=acl)
+                    report = md5s3stash("file://" + url, settings.S3_STASH)
                     field_instance.storage.delete(name)
                     field_instance.name = report.md5
                     upload_to = self._meta.get_field(s3field).upload_to
@@ -294,11 +290,7 @@ class HistoricalEssay(models.Model):
                 url = settings.MEDIA_ROOT + "/" + name
                 if os.path.isfile(url):
                     field_instance = getattr(self, s3field)
-                    if settings.S3_STASH_ACL:
-                        acl=settings.S3_STASH_ACL
-                    else:
-                        acl=None
-                    report = md5s3stash("file://" + url, settings.S3_STASH, acl=acl)
+                    report = md5s3stash("file://" + url, settings.S3_STASH)
                     field_instance.storage.delete(name)
                     field_instance.name = report.md5
                     upload_to = self._meta.get_field(s3field).upload_to
@@ -418,11 +410,7 @@ class LessonPlan(models.Model):
                 url = settings.MEDIA_ROOT + "/" + name
                 if os.path.isfile(url):
                     field_instance = getattr(self, s3field)
-                    if settings.S3_STASH_ACL:
-                        acl=settings.S3_STASH_ACL
-                    else:
-                        acl=None
-                    report = md5s3stash("file://" + url, settings.S3_STASH, acl=acl)
+                    report = md5s3stash("file://" + url, settings.S3_STASH)
                     field_instance.storage.delete(name)
                     field_instance.name = report.md5
                     upload_to = self._meta.get_field(s3field).upload_to
@@ -519,11 +507,7 @@ class Theme(models.Model):
                 url = settings.MEDIA_ROOT + "/" + name
                 if os.path.isfile(url):
                     field_instance = getattr(self, s3field)
-                    if settings.S3_STASH_ACL:
-                        acl=settings.S3_STASH_ACL
-                    else:
-                        acl=None
-                    report = md5s3stash("file://" + url, settings.S3_STASH, acl=acl)
+                    report = md5s3stash("file://" + url, settings.S3_STASH)
                     field_instance.storage.delete(name)
                     field_instance.name = report.md5
                     upload_to = self._meta.get_field(s3field).upload_to
@@ -626,11 +610,7 @@ class ExhibitItem(models.Model):
                 url = settings.MEDIA_ROOT + "/" + name
                 if os.path.isfile(url):
                     field_instance = getattr(self, s3field)
-                    if settings.S3_STASH_ACL:
-                        acl=settings.S3_STASH_ACL
-                    else:
-                        acl=None
-                    report = md5s3stash("file://" + url, settings.S3_STASH, acl=acl)
+                    report = md5s3stash("file://" + url, settings.S3_STASH)
                     field_instance.storage.delete(name)
                     field_instance.name = report.md5
                     upload_to = self._meta.get_field(s3field).upload_to

--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -10,7 +10,6 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.conf import settings
 from exhibits.custom_fields import HeroField
 from past import autotranslate
-autotranslate(['md5s3stash'])
 from md5s3stash import md5s3stash
 
 try:
@@ -219,7 +218,7 @@ class Exhibit(models.Model):
                 url = settings.MEDIA_ROOT + "/" + name
                 if os.path.isfile(url):
                     field_instance = getattr(self, s3field)
-                    report = md5s3stash("file://" + url, settings.S3_STASH)
+                    report = md5s3stash("file://" + url, settings.S3_STASH, settings.S3_ID)
                     field_instance.storage.delete(name)
                     field_instance.name = report.md5
                     upload_to = self._meta.get_field(s3field).upload_to
@@ -290,7 +289,7 @@ class HistoricalEssay(models.Model):
                 url = settings.MEDIA_ROOT + "/" + name
                 if os.path.isfile(url):
                     field_instance = getattr(self, s3field)
-                    report = md5s3stash("file://" + url, settings.S3_STASH)
+                    report = md5s3stash("file://" + url, settings.S3_STASH, settings.S3_ID)
                     field_instance.storage.delete(name)
                     field_instance.name = report.md5
                     upload_to = self._meta.get_field(s3field).upload_to
@@ -410,7 +409,7 @@ class LessonPlan(models.Model):
                 url = settings.MEDIA_ROOT + "/" + name
                 if os.path.isfile(url):
                     field_instance = getattr(self, s3field)
-                    report = md5s3stash("file://" + url, settings.S3_STASH)
+                    report = md5s3stash("file://" + url, settings.S3_STASH, settings.S3_ID)
                     field_instance.storage.delete(name)
                     field_instance.name = report.md5
                     upload_to = self._meta.get_field(s3field).upload_to
@@ -507,7 +506,7 @@ class Theme(models.Model):
                 url = settings.MEDIA_ROOT + "/" + name
                 if os.path.isfile(url):
                     field_instance = getattr(self, s3field)
-                    report = md5s3stash("file://" + url, settings.S3_STASH)
+                    report = md5s3stash("file://" + url, settings.S3_STASH, settings.S3_ID)
                     field_instance.storage.delete(name)
                     field_instance.name = report.md5
                     upload_to = self._meta.get_field(s3field).upload_to
@@ -610,7 +609,7 @@ class ExhibitItem(models.Model):
                 url = settings.MEDIA_ROOT + "/" + name
                 if os.path.isfile(url):
                     field_instance = getattr(self, s3field)
-                    report = md5s3stash("file://" + url, settings.S3_STASH)
+                    report = md5s3stash("file://" + url, settings.S3_STASH, settings.S3_ID)
                     field_instance.storage.delete(name)
                     field_instance.name = report.md5
                     upload_to = self._meta.get_field(s3field).upload_to

--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -223,7 +223,7 @@ class Exhibit(models.Model):
                         acl=settings.S3_STASH_ACL
                     else:
                         acl=None
-                    report = md5s3stash("file://" + url, settings.S3_STASH, acl)
+                    report = md5s3stash("file://" + url, settings.S3_STASH, acl=acl)
                     field_instance.storage.delete(name)
                     field_instance.name = report.md5
                     upload_to = self._meta.get_field(s3field).upload_to
@@ -298,7 +298,7 @@ class HistoricalEssay(models.Model):
                         acl=settings.S3_STASH_ACL
                     else:
                         acl=None
-                    report = md5s3stash("file://" + url, settings.S3_STASH, acl)
+                    report = md5s3stash("file://" + url, settings.S3_STASH, acl=acl)
                     field_instance.storage.delete(name)
                     field_instance.name = report.md5
                     upload_to = self._meta.get_field(s3field).upload_to
@@ -422,7 +422,7 @@ class LessonPlan(models.Model):
                         acl=settings.S3_STASH_ACL
                     else:
                         acl=None
-                    report = md5s3stash("file://" + url, settings.S3_STASH, acl)
+                    report = md5s3stash("file://" + url, settings.S3_STASH, acl=acl)
                     field_instance.storage.delete(name)
                     field_instance.name = report.md5
                     upload_to = self._meta.get_field(s3field).upload_to
@@ -523,7 +523,7 @@ class Theme(models.Model):
                         acl=settings.S3_STASH_ACL
                     else:
                         acl=None
-                    report = md5s3stash("file://" + url, settings.S3_STASH, acl)
+                    report = md5s3stash("file://" + url, settings.S3_STASH, acl=acl)
                     field_instance.storage.delete(name)
                     field_instance.name = report.md5
                     upload_to = self._meta.get_field(s3field).upload_to
@@ -630,7 +630,7 @@ class ExhibitItem(models.Model):
                         acl=settings.S3_STASH_ACL
                     else:
                         acl=None
-                    report = md5s3stash("file://" + url, settings.S3_STASH, acl)
+                    report = md5s3stash("file://" + url, settings.S3_STASH, acl=acl)
                     field_instance.storage.delete(name)
                     field_instance.name = report.md5
                     upload_to = self._meta.get_field(s3field).upload_to

--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -219,7 +219,11 @@ class Exhibit(models.Model):
                 url = settings.MEDIA_ROOT + "/" + name
                 if os.path.isfile(url):
                     field_instance = getattr(self, s3field)
-                    report = md5s3stash("file://" + url, settings.S3_STASH)
+                    if settings.S3_STASH_ACL:
+                        acl=settings.S3_STASH_ACL
+                    else:
+                        acl=None
+                    report = md5s3stash("file://" + url, settings.S3_STASH, acl)
                     field_instance.storage.delete(name)
                     field_instance.name = report.md5
                     upload_to = self._meta.get_field(s3field).upload_to
@@ -290,7 +294,11 @@ class HistoricalEssay(models.Model):
                 url = settings.MEDIA_ROOT + "/" + name
                 if os.path.isfile(url):
                     field_instance = getattr(self, s3field)
-                    report = md5s3stash("file://" + url, settings.S3_STASH)
+                    if settings.S3_STASH_ACL:
+                        acl=settings.S3_STASH_ACL
+                    else:
+                        acl=None
+                    report = md5s3stash("file://" + url, settings.S3_STASH, acl)
                     field_instance.storage.delete(name)
                     field_instance.name = report.md5
                     upload_to = self._meta.get_field(s3field).upload_to
@@ -410,7 +418,11 @@ class LessonPlan(models.Model):
                 url = settings.MEDIA_ROOT + "/" + name
                 if os.path.isfile(url):
                     field_instance = getattr(self, s3field)
-                    report = md5s3stash("file://" + url, settings.S3_STASH)
+                    if settings.S3_STASH_ACL:
+                        acl=settings.S3_STASH_ACL
+                    else:
+                        acl=None
+                    report = md5s3stash("file://" + url, settings.S3_STASH, acl)
                     field_instance.storage.delete(name)
                     field_instance.name = report.md5
                     upload_to = self._meta.get_field(s3field).upload_to
@@ -507,7 +519,11 @@ class Theme(models.Model):
                 url = settings.MEDIA_ROOT + "/" + name
                 if os.path.isfile(url):
                     field_instance = getattr(self, s3field)
-                    report = md5s3stash("file://" + url, settings.S3_STASH)
+                    if settings.S3_STASH_ACL:
+                        acl=settings.S3_STASH_ACL
+                    else:
+                        acl=None
+                    report = md5s3stash("file://" + url, settings.S3_STASH, acl)
                     field_instance.storage.delete(name)
                     field_instance.name = report.md5
                     upload_to = self._meta.get_field(s3field).upload_to
@@ -610,7 +626,11 @@ class ExhibitItem(models.Model):
                 url = settings.MEDIA_ROOT + "/" + name
                 if os.path.isfile(url):
                     field_instance = getattr(self, s3field)
-                    report = md5s3stash("file://" + url, settings.S3_STASH)
+                    if settings.S3_STASH_ACL:
+                        acl=settings.S3_STASH_ACL
+                    else:
+                        acl=None
+                    report = md5s3stash("file://" + url, settings.S3_STASH, acl)
                     field_instance.storage.delete(name)
                     field_instance.name = report.md5
                     upload_to = self._meta.get_field(s3field).upload_to

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 Django>=1.11.22,==1.11.*
 future==0.16.0
 requests==2.21.0
-https://github.com/amywieliczka/md5s3stash/archive/add-acl.zip#egg=md5s3stash
 markdown==2.6.8
+boto3==1.12.25
+pilbox==1.3.4
+Pillow==5.2.0
+python-magic==0.4.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django>=1.11.22,==1.11.*
 future==0.16.0
 requests==2.21.0
-https://github.com/amywieliczka/md5s3stash/archive/python3.zip#egg=md5s3stash
+https://github.com/amywieliczka/md5s3stash/archive/add-acl.zip#egg=md5s3stash
 markdown==2.6.8


### PR DESCRIPTION
No longer downloads a file from a url to a temporary file in order to produce md5 (unnecessary since in this case, the file is already in the local file system)

Call to upload the file to s3 must GrantRead AND GrantFullControl - permissions can't be set with an ACL because only one ACL is allowed, and we need both 'public-read' and 'bucket-owner-full-control', so these must be explicitly set via GrantRead and GrantFullControl. 

I wasn't able to find much documentation for boto2 on how to do this, but was able to find a lot of documentation on boto3 and it kind of made some sense to update anyway. 