### PR TITLE
Django 3.2

### DIFF
--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -6,7 +6,6 @@ import re
 from django.contrib.auth.models import User
 from django.db import models
 from django.urls import reverse
-from django.utils.encoding import python_2_unicode_compatible
 from django.conf import settings
 from exhibits.custom_fields import HeroField
 from exhibits.md5s3stash import md5s3stash
@@ -79,7 +78,6 @@ class PublishedExhibitManager(models.Manager):
         else:
             return super(PublishedExhibitManager, self).get_queryset().filter(publish=True)
 
-@python_2_unicode_compatible
 class Exhibit(models.Model):
     title = models.CharField(max_length=512)
     slug = models.SlugField(max_length=255, unique=True)
@@ -200,7 +198,6 @@ class PublishedHistoricalEssayManager(models.Manager):
         else:
             return super(PublishedHistoricalEssayManager, self).get_queryset().filter(publish=True)
 
-@python_2_unicode_compatible
 class HistoricalEssay(models.Model):
     title = models.CharField(max_length=200)
     slug = models.SlugField(max_length=255, unique=True)
@@ -300,7 +297,6 @@ class PublishedLessonPlanManager(models.Manager):
         else:
             return super(PublishedLessonPlanManager, self).get_queryset().filter(publish=True)
 
-@python_2_unicode_compatible
 class LessonPlan(models.Model):
     title = models.CharField(max_length=200)
     sub_title = models.CharField(max_length=512, blank=True)
@@ -391,7 +387,6 @@ class PublishedThemeManager(models.Manager):
         else:
             return super(PublishedThemeManager, self).get_queryset().filter(publish=True)
 
-@python_2_unicode_compatible
 class Theme(models.Model):
     title = models.CharField(max_length=200)
     sort_title = models.CharField(blank=True, max_length=200, verbose_name='Sortable Title')
@@ -503,7 +498,6 @@ class PublishedExhibitItemManager(models.Manager):
         else:
             return super(PublishedExhibitItemManager, self).get_queryset().filter(publish=True)
 
-@python_2_unicode_compatible
 class ExhibitItem(models.Model):
     item_id = models.CharField(max_length=200)
 
@@ -586,7 +580,6 @@ class ExhibitItem(models.Model):
                     super(ExhibitItem, self).save(update_fields=[s3field])
                     self._meta.get_field(s3field).upload_to = upload_to
 
-@python_2_unicode_compatible
 class NotesItem(models.Model):
     title = models.CharField(max_length=200)
     exhibit = models.ForeignKey(Exhibit, on_delete=models.CASCADE)
@@ -621,7 +614,6 @@ class LessonPlanExhibit(models.Model):
         ordering = ['order']
 
 # Exhibits ordered within Themes
-@python_2_unicode_compatible
 class ExhibitTheme(models.Model):
     exhibit = models.ForeignKey(Exhibit, on_delete=models.CASCADE)
     theme = models.ForeignKey(Theme, on_delete=models.CASCADE)

--- a/exhibits/templatetags/markdown_filter.py
+++ b/exhibits/templatetags/markdown_filter.py
@@ -6,10 +6,14 @@ from markdown.extensions import Extension
 # per notes in the release docs for version 2.5, used an EscapeHTML 
 # extension to replace safe_mode="escape" (deprecated)
 
+# https://python-markdown.github.io/changelog/#safe_mode-and-html_replacement_text-keywords-deprecated
+# https://python-markdown.github.io/changelog/#md_globals-keyword-deprecated-from-extension-api
+# https://python-markdown.github.io/changelog/#previously-deprecated-objects-have-been-removed
+
 class EscapeHtml(Extension):
-	def extendMarkdown(self, md, md_globals):
-		del md.preprocessors['html_block']
-		del md.inlinePatterns['html']
+	def extendMarkdown(self, md):
+		md.preprocessors.deregister('html_block')
+		md.inlinePatterns.deregister('html')
 
 register = Library()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-Django>=1.11.22,==1.11.*
-future==0.16.0
-requests==2.21.0
-markdown==2.6.8
-boto3==1.12.25
-pilbox==1.3.4
-Pillow==5.2.0
-python-magic==0.4.15
+Django>=1.11.22,<=3.2.*
+future==0.18.3
+requests==2.31.0
+markdown==3.4.4
+boto3==1.33.13
+Pillow==9.5.0
+python-magic==0.4.27
+retrying==1.3.4


### PR DESCRIPTION
Changes required for an upgrade to Django 3.2

Django 3.2 branch is deployed to registry-stg and registry-prd, but Calisphere also uses exhibitapp and is still on Django 1.11

We should either upgrade Calisphere to use Django 3.2 very soon, or tag master prior to merging this PR and continue to use the outdated tagged version in Calisphere. Let's hold on merging this PR until we've made that decision. 