### PR TITLE
Required to run on M2 Mac

### DIFF
--- a/exhibits/md5s3stash.py
+++ b/exhibits/md5s3stash.py
@@ -2,13 +2,12 @@
 """ md5s3stash
     content addressable storage in AWS S3
 """
+import mimetypes
 import urllib.parse
 import logging
 import hashlib
 import boto3
 from botocore.errorfactory import ClientError
-import magic
-from PIL import Image
 from collections import namedtuple
 
 
@@ -81,6 +80,8 @@ def image_info(filepath):
             2. a tuple of (height, width) if an image; otherwise (0,0)
     '''
     try:
+        import magic
+        from PIL import Image
         return (
             magic.Magic(mime=True).from_file(filepath),
             Image.open(filepath).size
@@ -90,5 +91,5 @@ def image_info(filepath):
             raise e
         else:
             return (None, (0,0))
-
-
+    except ImportError:
+        return (mimetypes.guess_type(filepath), (0,0))


### PR DESCRIPTION
I think this will continue to use ImageMagic if it's available, but skip it if it is not. 

Contextually, this module is only used when exhibitapp is deployed to the collection registry (the exhibition editing interface), however, it is imported within models.py and used as part of the `save()` method on many exhibition models to upload image files for configured image fields to s3. Furthermore, the dimensions and mimetype pieces of this module (which are the parts that require ImageMagic), don't seem to be used, except that mimetype is sent to `s3.upload_file` as the `ContentType`. 