### PR TITLE
Integrate OpenSearch without sacrificing Solr

### DIFF
--- a/exhibits/admin.py
+++ b/exhibits/admin.py
@@ -2,6 +2,7 @@
 
 
 from django.contrib import admin
+from django.http import HttpRequest
 from django.utils.safestring import mark_safe
 from django import forms
 from django.db import models
@@ -27,23 +28,32 @@ class ExhibitItemInline(admin.TabularInline):
         return mark_safe(f"<a href='{link}'>Click to add custom crop, link, title, and metadata</a>")
     link_to_exhibit_item.short_description="Link to Exhibit Item"
 
+    def get_queryset(self, request: HttpRequest) -> models.QuerySet:
+        self.calisphere_index = request.session.get('index')
+        return super().get_queryset(request)
+
     def img_display(self, instance):
-        if instance.imgUrl():
-            return mark_safe("<img src='" + instance.imgUrl() + "'/>")
+        if instance.imgUrl(self.calisphere_index):
+            return mark_safe("<img src='" + instance.imgUrl(self.calisphere_index) + "'/>")
         else:
             return None
+
     img_display.short_description = "Thumbnail"
 
 class LessonPlanItemInline(admin.TabularInline):
     model = ExhibitItem
     classes = ('collapse',)
     fields = ['lesson_plan_order', 'publish', 'item_id', 'essay', 'render_as', 'img_display', 'citations', 'citations_render_as', 'link_to_exhibit_item']
-    # 'imgUrl', 'custom_crop', 'custom_link', 'custom_title', 'custom_metadata', 'metadata_render_as'
+    # 'img_url', 'custom_crop', 'custom_link', 'custom_title', 'custom_metadata', 'metadata_render_as'
     extra = 0
     formfield_overrides = {
         models.TextField: {'widget': forms.Textarea(attrs={'cols': 50, 'rows': 5})}
     }
-    readonly_fields = ['imgUrl', 'img_display', 'link_to_exhibit_item']
+    readonly_fields = ['img_url', 'img_display', 'link_to_exhibit_item']
+
+    def get_queryset(self, request: HttpRequest) -> models.QuerySet:
+        self.calisphere_index = request.session.get('index')
+        return super().get_queryset(request)
 
     def link_to_exhibit_item(self, instance):
         link = reverse("admin:exhibits_exhibititem_change", args=[instance.id])
@@ -51,34 +61,44 @@ class LessonPlanItemInline(admin.TabularInline):
     link_to_exhibit_item.short_description="Link to Lesson Plan Item"
 
     def img_display(self, instance):
-        if instance.imgUrl():
-            return mark_safe("<img src='" + instance.imgUrl() + "'/>")
+        if instance.imgUrl(self.calisphere_index):
+            return mark_safe("<img src='" + instance.imgUrl(self.calisphere_index) + "'/>")
         else:
             return None
     img_display.short_description = "Thumbnail"
+
+    def img_url(self, instance):
+        return instance.imgUrl(self.calisphere_index)
 
 class HistoricalEssayItemInline(admin.TabularInline):
     model = ExhibitItem
     classes = ('collapse',)
     fields = ['historical_essay_order', 'publish', 'item_id', 'essay', 'render_as', 'img_display', 'citations', 'citations_render_as', 'link_to_exhibit_item']
-    # 'imgUrl', 'custom_crop', 'custom_link', 'custom_title', 'custom_metadata', 'metadata_render_as'
+    # 'img_url', 'custom_crop', 'custom_link', 'custom_title', 'custom_metadata', 'metadata_render_as'
     extra = 0
     formfield_overrides = {
         models.TextField: {'widget': forms.Textarea(attrs={'cols': 50, 'rows': 5})}
     }
-    readonly_fields = ['imgUrl', 'img_display', 'link_to_exhibit_item']
+    readonly_fields = ['img_url', 'img_display', 'link_to_exhibit_item']
 
     def link_to_exhibit_item(self, instance):
         link = reverse("admin:exhibits_exhibititem_change", args=[instance.id])
         return mark_safe(f"<a href='{link}'>Click to add custom crop, link, title, and metadata</a>")
     link_to_exhibit_item.short_description="Link to Historical Essay Item"
 
+    def get_queryset(self, request: HttpRequest) -> models.QuerySet:
+        self.calisphere_index = request.session.get('index')
+        return super().get_queryset(request)
+
     def img_display(self, instance):
-        if instance.imgUrl():
-            return mark_safe("<img src='" + instance.imgUrl() + "'/>")
+        if instance.imgUrl(self.calisphere_index):
+            return mark_safe("<img src='" + instance.imgUrl(self.calisphere_index) + "'/>")
         else:
             return None
     img_display.short_description = "Thumbnail"
+
+    def img_url(self, instance):
+        return instance.imgUrl(self.calisphere_index)
 
 class NotesItemInline(admin.TabularInline):
     model = NotesItem
@@ -257,9 +277,13 @@ class ExhibitItemAdmin(admin.ModelAdmin):
 
     readonly_fields = ['container_type', 'container', 'container_order', 'img_display', 'return_to_container']
 
+    def get_queryset(self, request: HttpRequest) -> models.QuerySet:
+        self.calisphere_index = request.session.get('index')
+        return super().get_queryset(request)
+
     def img_display(self, instance):
-        if instance.imgUrl():
-            return mark_safe("<img src='" + instance.imgUrl() + "'/>")
+        if instance.imgUrl(self.calisphere_index):
+            return mark_safe("<img src='" + instance.imgUrl(self.calisphere_index) + "'/>")
         else:
             return None
     img_display.short_description = "Thumbnail"

--- a/exhibits/cache_retry.py
+++ b/exhibits/cache_retry.py
@@ -9,14 +9,13 @@ from collections import namedtuple
 import urllib3
 from retrying import retry
 import requests
-import pickle
-import hashlib
 import json
 import itertools
 import re
 from typing import Dict, List, Tuple
 
 from django.http import JsonResponse
+from exhibits.utils import kwargs_md5
 
 urllib3.disable_warnings()
 
@@ -170,13 +169,6 @@ def SOLR(**params):
         facet_counts,
         results.get('nextCursorMark'),
     )
-
-
-# create a hash for a cache key
-def kwargs_md5(**kwargs):
-    m = hashlib.md5()
-    m.update(pickle.dumps(kwargs))
-    return m.hexdigest()
 
 
 # dummy class for holding cached data

--- a/exhibits/es_cache_retry.py
+++ b/exhibits/es_cache_retry.py
@@ -1,0 +1,259 @@
+""" logic for cache / retry for es (opensearch) and JSON from registry
+"""
+
+from future import standard_library
+from django.core.cache import cache
+from django.conf import settings
+
+from collections import namedtuple
+import urllib.request
+import urllib.error
+from urllib.parse import urlparse
+from retrying import retry
+import urllib3
+import pickle
+import hashlib
+import json
+from typing import Dict, List, Tuple, Optional
+from aws_xray_sdk.core import patch
+from elasticsearch import Elasticsearch
+from elasticsearch.exceptions import ConnectionError as ESConnectionError
+
+urllib3.disable_warnings()
+standard_library.install_aliases()
+
+if hasattr(settings, 'XRAY_RECORDER'):
+    patch(('requests', ))
+
+if not settings.ES_HOST or not settings.ES_USER or not settings.ES_PASS:
+    raise ImportError("ES settings not defined")
+
+elastic_client = Elasticsearch(
+    hosts=[settings.ES_HOST],
+    http_auth=(settings.ES_USER, settings.ES_PASS))
+
+ESResults = namedtuple(
+    'ESResults', 'results numFound facet_counts')
+ESItem = namedtuple(
+    'ESItem', 'found, item, resp')
+
+
+def es_search(body) -> ESResults:
+    try:
+        results = elastic_client.search(
+            index=settings.ES_ALIAS, body=json.dumps(body))
+    except ESConnectionError as e:
+        raise ConnectionError(
+            f"No OpenSearch connection: {settings.ES_HOST}") from e
+
+    aggs = results.get('aggregations')
+    facet_counts = {'facet_fields': {}}
+    if aggs:
+        for facet_field in aggs:
+            buckets = aggs[facet_field].get('buckets')
+            facet_values = {b['key']: b['doc_count'] for b in buckets}
+            facet_counts['facet_fields'][facet_field] = facet_values
+    else:
+        facet_counts = {}
+
+    for result in results['hits']['hits']:
+        metadata = result.pop('_source')
+        # TODO replace type_ss with type globally
+        metadata['type_ss'] = metadata.get('type')
+        # TODO replace reference_image_md5 globally
+        thumbnail_key = get_thumbnail_key(metadata)
+        if thumbnail_key:
+            metadata['reference_image_md5'] = thumbnail_key
+        result.update(metadata)
+
+    results = ESResults(
+        results['hits']['hits'],
+        results['hits']['total']['value'],
+        facet_counts)
+
+    return results
+
+def get_thumbnail_key(metadata):
+    if metadata.get('thumbnail'):
+        path = metadata['thumbnail'].get('path','')
+        if path.startswith('s3://'):
+            uri_path = urlparse(path).path
+            key_parts = uri_path.split('/')[2:]
+            return '/'.join(key_parts)
+
+def es_search_nocache(**kwargs):
+    return es_search(kwargs)
+
+
+def es_get(item_id: str) -> Optional[ESItem]:
+    # cannot search Elasticsearch with empty string
+    if not item_id:
+        return None
+
+    # cannot use Elasticsearch.get() for multi-index alias
+    body = {'query': {'match': {'_id': item_id}}}
+    try:
+        item_search = elastic_client.search(
+            index=settings.ES_ALIAS, body=json.dumps(body))
+    except ESConnectionError as e:
+        raise ConnectionError(
+            f"No OpenSearch connection: {settings.ES_HOST}") from e
+    found = item_search['hits']['total']['value']
+    if not found:
+        return None
+    item = item_search['hits']['hits'][0]['_source']
+
+    item['collection_ids'] = item.get('collection_url')
+    item['repository_ids'] = item.get('repository_url')
+    thumbnail_key = get_thumbnail_key(item)
+    if thumbnail_key:
+        item['reference_image_md5'] = thumbnail_key
+
+    results = ESItem(found, item, item_search)
+    return results
+
+
+# create a hash for a cache key
+def kwargs_md5(**kwargs):
+    m = hashlib.md5()
+    m.update(pickle.dumps(kwargs))
+    return m.hexdigest()
+
+
+# wrapper function for json.loads(urllib2.urlopen)
+@retry(wait_exponential_multiplier=2, stop_max_delay=10000)  # milliseconds
+def json_loads_url(url_or_req):
+    key = kwargs_md5(key='json_loads_url', url=url_or_req)
+    data = cache.get(key)
+    if not data:
+        try:
+            data = json.loads(
+                urllib.request.urlopen(url_or_req).read().decode('utf-8'))
+        except urllib.error.HTTPError:
+            data = {}
+    return data
+
+
+def es_mlt(item_id):
+    first_item = es_get(item_id)
+    es_query = {
+        "query": {
+            "more_like_this": {
+                "fields": [
+                    "title.keyword",
+                    "collection_data",
+                    "subject.keyword",
+                    "thumbnail"
+                ],
+                "like": [
+                    {"_id": item_id}
+                ],
+                "min_term_freq": 1
+            }
+        },
+        "_source": ["id", "type", "thumbnail", "title"],
+        "size": 24
+    }
+    mlt_results = es_search(es_query)
+    mlt_results.results.insert(0, first_item.item)
+    return mlt_results
+
+
+FieldName = str
+Order = str
+FilterValues = list
+FilterField = Dict[FieldName, FilterValues]
+Filters = List[FilterField]
+
+
+def query_encode(query_string: str = None, 
+                 filters: Filters = None,
+                 exclude: Filters = None,
+                 sort: Tuple[FieldName, Order] = None,
+                 start: int = None,
+                 rows: int = 0,
+                 result_fields: List[str] = None,
+                 facets: List[str] = None,
+                 facet_sort: dict = None):
+
+    es_params = {}
+
+    es_query = es_filters = es_exclude = None
+
+    if query_string:
+        es_query = [{
+            "query_string": {
+                "query": query_string
+            }
+        }]
+
+    if filters:
+        es_filters = [{
+            'terms': {k: v} for k, v in f.items()
+        } for f in filters]
+
+    if exclude:
+        es_exclude = [{
+            'terms': {k: v} for k, v in e.items()
+        } for e in exclude]
+
+    if es_query or es_filters or es_exclude:
+        es_params['query'] = {'bool': {}}
+        if es_query:
+            es_params['query']['bool']['must'] = es_query
+        if es_filters:
+            es_params['query']['bool']['filter'] = es_filters
+        if es_exclude:
+            es_params['query']['bool']['must_not'] = es_exclude
+
+        # unsure if this is an unnecessary optimization:
+        # https://discuss.elastic.co/t/filter-performance-difference-bool-vs-terms/59928
+        if len(es_params['query']['bool']) == 1:
+            if 'must' in es_params['query']['bool']:
+                es_params['query'] = es_query[0]
+            elif ('filter' in es_params['query']['bool'] and 
+                  len(es_params['query']['bool']['filter']) == 1):
+                es_params['query'] = es_filters[0]
+
+    if facets:
+        # TODO tidy this up when we settle on a field type for these
+        #exceptions = ['repository_url', 'collection_url', 'campus_url']
+        exceptions = []
+        aggs = {}
+        for facet in facets:
+            if facet in exceptions or facet[-8:] == '.keyword':
+                field = facet
+            else:
+                field = f'{facet}.keyword'
+
+            aggs[facet] = {
+                "terms": {
+                    "field": field,
+                    "size": 10000
+                }
+            }
+
+            if facet_sort:
+                aggs[facet]["terms"]["order"] = facet_sort
+        # regarding 'size' parameter here and getting back all the facet values
+        # please see: https://github.com/elastic/elasticsearch/issues/18838
+        es_params.update({"aggs": aggs})
+
+    if result_fields:
+        es_params.update({"_source": result_fields})
+
+    # if sort:
+    #     es_params.update({
+    #         "sort": [{
+    #             sort[0]: {"order": sort[1]}
+    #         }]
+    #     })
+    
+    es_params.update({'size': rows})
+    if start:
+        es_params.update({'from': start})
+    return es_params
+
+
+def search_es(query):
+    return es_search(query_encode(**query))

--- a/exhibits/es_cache_retry.py
+++ b/exhibits/es_cache_retry.py
@@ -1,7 +1,6 @@
 """ logic for cache / retry for es (opensearch) and JSON from registry
 """
 
-from future import standard_library
 from django.core.cache import cache
 from django.conf import settings
 
@@ -16,7 +15,6 @@ from elasticsearch.exceptions import ConnectionError as ESConnectionError
 from elasticsearch.exceptions import RequestError as ESRequestError
 
 urllib3.disable_warnings()
-standard_library.install_aliases()
 
 if hasattr(settings, 'XRAY_RECORDER'):
     patch(('requests', ))

--- a/exhibits/es_cache_retry.py
+++ b/exhibits/es_cache_retry.py
@@ -113,27 +113,6 @@ def es_get(item_id: str) -> Optional[ESItem]:
     return results
 
 
-# create a hash for a cache key
-def kwargs_md5(**kwargs):
-    m = hashlib.md5()
-    m.update(pickle.dumps(kwargs))
-    return m.hexdigest()
-
-
-# wrapper function for json.loads(urllib2.urlopen)
-@retry(wait_exponential_multiplier=2, stop_max_delay=10000)  # milliseconds
-def json_loads_url(url_or_req):
-    key = kwargs_md5(key='json_loads_url', url=url_or_req)
-    data = cache.get(key)
-    if not data:
-        try:
-            data = json.loads(
-                urllib.request.urlopen(url_or_req).read().decode('utf-8'))
-        except urllib.error.HTTPError:
-            data = {}
-    return data
-
-
 def es_mlt(item_id):
     first_item = es_get(item_id)
     es_query = {

--- a/exhibits/es_cache_retry.py
+++ b/exhibits/es_cache_retry.py
@@ -113,6 +113,11 @@ def es_get(item_id: str) -> Optional[ESItem]:
     return results
 
 
+def es_get_ids(ids: List[str]) -> ESResults:
+    body = {'query': {'ids': {'values': ids}}}
+    return es_search(body)
+
+
 def es_mlt(item_id):
     first_item = es_get(item_id)
     es_query = {

--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -563,7 +563,7 @@ class ExhibitItem(models.Model):
         else:
             return None
 
-    def imgUrl(self, index="solr"):
+    def imgUrl(self, index):
         if self.custom_crop:
             return settings.THUMBNAIL_URL + "crop/210x210/" + self.custom_crop.name
         else:

--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -64,7 +64,7 @@ def getRepositoryData(repository_data):
 
     return repository
 
-def get_reference_image_md5(item_id, index='solr'):
+def get_reference_image_md5(item_id, index):
     item_id_search_term = 'id:"{0}"'.format(item_id)
     item_search = None
     if index == 'solr':
@@ -147,13 +147,13 @@ class Exhibit(models.Model):
     def get_absolute_url(self):
         return reverse('exhibits:exhibitView', kwargs={'exhibit_id': self.id, 'exhibit_slug': self.slug})
 
-    def exhibit_lockup(self):
+    def exhibit_lockup(self, index):
         if self.lockup_derivative:
             return settings.THUMBNAIL_URL + "crop/273x182/" + self.lockup_derivative.name
         elif self.hero_first:
             return settings.THUMBNAIL_URL + "crop/273x182/" + self.hero.name
         else:
-            reference_image_md5 = get_reference_image_md5(self.item_id)
+            reference_image_md5 = get_reference_image_md5(self.item_id, index)
             if reference_image_md5:
                 return settings.THUMBNAIL_URL + "crop/273x182/" + reference_image_md5
             elif self.hero:
@@ -161,11 +161,11 @@ class Exhibit(models.Model):
             else:
                 return None
 
-    def exhibit_lockup_sm(self):
+    def exhibit_lockup_sm(self, index):
         if self.hero_first:
             return settings.THUMBNAIL_URL + "crop/298x121/" + self.hero.name
         else:
-            reference_image_md5 = get_reference_image_md5(self.item_id)
+            reference_image_md5 = get_reference_image_md5(self.item_id, index)
             if reference_image_md5:
                return settings.THUMBNAIL_URL + "crop/298x121/" +  reference_image_md5
             elif self.hero:
@@ -173,9 +173,9 @@ class Exhibit(models.Model):
             else:
                 return None
 
-    def social_media_card(self):
+    def social_media_card(self, index):
         if self.item_id:
-            reference_image_md5 = get_reference_image_md5(self.item_id)
+            reference_image_md5 = get_reference_image_md5(self.item_id, index)
             if reference_image_md5:
                return settings.THUMBNAIL_URL + "clip/999x999/" +  reference_image_md5
             elif self.hero:
@@ -272,11 +272,11 @@ class HistoricalEssay(models.Model):
                     super(HistoricalEssay, self).save(update_fields=[s3field])
                     self._meta.get_field(s3field).upload_to = upload_to
 
-    def lockup(self):
+    def lockup(self, index):
         if self.hero_first:
             return settings.THUMBNAIL_URL + "crop/298x121/" + self.hero.name
         else:
-            reference_image_md5 = get_reference_image_md5(self.item_id)
+            reference_image_md5 = get_reference_image_md5(self.item_id, index)
             if reference_image_md5:
                return settings.THUMBNAIL_URL + "crop/298x121/" +  reference_image_md5
             elif self.hero:
@@ -284,9 +284,9 @@ class HistoricalEssay(models.Model):
             else:
                 return None
 
-    def social_media_card(self):
+    def social_media_card(self, index):
         if self.item_id:
-            reference_image_md5 = get_reference_image_md5(self.item_id)
+            reference_image_md5 = get_reference_image_md5(self.item_id, index)
             if reference_image_md5:
                return settings.THUMBNAIL_URL + "clip/999x999/" +  reference_image_md5
             elif self.hero:
@@ -350,21 +350,21 @@ class LessonPlan(models.Model):
     def get_absolute_url(self):
         return reverse('for-teachers:lessonPlanView', kwargs={'lesson_id': self.id, 'lesson_slug': self.slug})
 
-    def lockup(self):
+    def lockup(self, index):
         if self.lockup_derivative:
             return settings.THUMBNAIL_URL + "crop/298x121/" + self.lockup_derivative.name
         else:
-            reference_image_md5 = get_reference_image_md5(self.item_id)
+            reference_image_md5 = get_reference_image_md5(self.item_id, index)
             if reference_image_md5:
                return settings.THUMBNAIL_URL + "crop/298x121/" +  reference_image_md5
             else:
                 return None
 
-    def social_media_card(self):
+    def social_media_card(self, index):
         if self.lockup_derivative:
             return settings.THUMBNAIL_URL + "clip/999x999/" + self.lockup_derivative.name
         else:
-            reference_image_md5 = get_reference_image_md5(self.item_id)
+            reference_image_md5 = get_reference_image_md5(self.item_id, index)
             if reference_image_md5:
                return settings.THUMBNAIL_URL + "clip/999x999/" +  reference_image_md5
             else:
@@ -451,13 +451,13 @@ class Theme(models.Model):
     def get_absolute_url(self):
         return reverse('exhibits:themeView', kwargs={'theme_id': self.id, 'theme_slug': self.slug})
 
-    def theme_lockup(self):
+    def theme_lockup(self, index):
         if self.lockup_derivative:
             return settings.THUMBNAIL_URL + "crop/420x210/" + self.lockup_derivative.name
         elif self.hero_first:
             return settings.THUMBNAIL_URL + "crop/420x210/" + self.hero.name
         else:
-            reference_image_md5 = get_reference_image_md5(self.item_id)
+            reference_image_md5 = get_reference_image_md5(self.item_id, index)
             if reference_image_md5:
                return settings.THUMBNAIL_URL + "crop/420x210/" +  reference_image_md5
             elif self.hero:
@@ -482,9 +482,9 @@ class Theme(models.Model):
                     super(Theme, self).save(update_fields=[s3field])
                     self._meta.get_field(s3field).upload_to = upload_to
 
-    def social_media_card(self):
+    def social_media_card(self, index):
         if self.item_id:
-            reference_image_md5 = get_reference_image_md5(self.item_id)
+            reference_image_md5 = get_reference_image_md5(self.item_id, index)
             if reference_image_md5:
                return settings.THUMBNAIL_URL + "clip/999x999/" +  reference_image_md5
             elif self.hero:
@@ -540,7 +540,7 @@ class ExhibitItem(models.Model):
     def __str__(self):
         return self.item_id
 
-    def indexedData(self, index='solr'):
+    def indexedData(self, index):
         item_id_search_term = 'id:"{0}"'.format(self.item_id)
         item_search = None
         if index == 'solr':
@@ -563,11 +563,11 @@ class ExhibitItem(models.Model):
         else:
             return None
 
-    def imgUrl(self):
+    def imgUrl(self, index="solr"):
         if self.custom_crop:
             return settings.THUMBNAIL_URL + "crop/210x210/" + self.custom_crop.name
         else:
-            reference_image_md5 = get_reference_image_md5(self.item_id)
+            reference_image_md5 = get_reference_image_md5(self.item_id, index)
             if reference_image_md5:
                return settings.THUMBNAIL_URL + "crop/210x210/" +  reference_image_md5
             else:

--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -11,9 +11,9 @@ from exhibits.custom_fields import HeroField
 from exhibits.md5s3stash import md5s3stash
 
 try:
-    from calisphere.cache_retry import SOLR_select
+    from calisphere.cache_retry import SOLR_get
 except ImportError:
-    from exhibits.cache_retry import SOLR_select
+    from exhibits.cache_retry import SOLR_get
 
 RENDERING_OPTIONS = (
     ('H', 'HTML'),
@@ -64,9 +64,9 @@ def getRepositoryData(repository_data):
 
 def get_reference_image_md5(item_id):
     item_id_search_term = 'id:"{0}"'.format(item_id)
-    item_solr_search = SOLR_select(q=item_id_search_term)
-    if len(item_solr_search.results) > 0 and 'reference_image_md5' in item_solr_search.results[0]:
-        return item_solr_search.results[0]['reference_image_md5']
+    item_search = SOLR_get(q=item_id_search_term)
+    if item_search and 'reference_image_md5' in item_search.item:
+        return item_search.item['reference_image_md5']
     else:
         return None
 
@@ -535,9 +535,9 @@ class ExhibitItem(models.Model):
 
     def solrData(self):
         item_id_search_term = 'id:"{0}"'.format(self.item_id)
-        item_solr_search = SOLR_select(q=item_id_search_term)
-        if len(item_solr_search.results) > 0:
-            item = item_solr_search.results[0]
+        item_search = SOLR_get(q=item_id_search_term)
+        if item_search:
+            item = item_search.item
 
             item['parsed_collection_data'] = []
             item['parsed_repository_data'] = []

--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -12,8 +12,10 @@ from exhibits.md5s3stash import md5s3stash
 
 try:
     from calisphere.cache_retry import SOLR_get
+    from calisphere.es_cache_retry import es_get
 except ImportError:
     from exhibits.cache_retry import SOLR_get
+    from exhibits.es_cache_retry import es_get
 
 RENDERING_OPTIONS = (
     ('H', 'HTML'),

--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -23,6 +23,17 @@ RENDERING_OPTIONS = (
     ('M', 'Markdown')
 )
 
+
+def get_thumbnail_url(index):
+    thumbnailUrl = settings.THUMBNAIL_URL
+    if settings.MULTI_INDEX:
+        if index == 'solr':
+            thumbnailUrl = settings.SOLR_THUMBNAILS
+        elif index == 'es':
+            thumbnailUrl = settings.THUMBNAIL_URL
+    return thumbnailUrl
+
+
 def getCollectionData(collection_data):
     collection = {}
     parts = collection_data.split('::')
@@ -149,27 +160,27 @@ class Exhibit(models.Model):
 
     def exhibit_lockup(self, index):
         if self.lockup_derivative:
-            return settings.THUMBNAIL_URL + "crop/273x182/" + self.lockup_derivative.name
+            return get_thumbnail_url(index) + "crop/273x182/" + self.lockup_derivative.name
         elif self.hero_first:
-            return settings.THUMBNAIL_URL + "crop/273x182/" + self.hero.name
+            return get_thumbnail_url(index) + "crop/273x182/" + self.hero.name
         else:
             reference_image_md5 = get_reference_image_md5(self.item_id, index)
             if reference_image_md5:
-                return settings.THUMBNAIL_URL + "crop/273x182/" + reference_image_md5
+                return get_thumbnail_url(index) + "crop/273x182/" + reference_image_md5
             elif self.hero:
-                return settings.THUMBNAIL_URL + "crop/273x182/" + self.hero.name
+                return get_thumbnail_url(index) + "crop/273x182/" + self.hero.name
             else:
                 return None
 
     def exhibit_lockup_sm(self, index):
         if self.hero_first:
-            return settings.THUMBNAIL_URL + "crop/298x121/" + self.hero.name
+            return get_thumbnail_url(index) + "crop/298x121/" + self.hero.name
         else:
             reference_image_md5 = get_reference_image_md5(self.item_id, index)
             if reference_image_md5:
-               return settings.THUMBNAIL_URL + "crop/298x121/" +  reference_image_md5
+               return get_thumbnail_url(index) + "crop/298x121/" +  reference_image_md5
             elif self.hero:
-                return settings.THUMBNAIL_URL + "crop/298x121/" + self.hero.name
+                return get_thumbnail_url(index) + "crop/298x121/" + self.hero.name
             else:
                 return None
 
@@ -177,13 +188,13 @@ class Exhibit(models.Model):
         if self.item_id:
             reference_image_md5 = get_reference_image_md5(self.item_id, index)
             if reference_image_md5:
-               return settings.THUMBNAIL_URL + "clip/999x999/" +  reference_image_md5
+               return get_thumbnail_url(index) + "clip/999x999/" +  reference_image_md5
             elif self.hero:
-                return settings.THUMBNAIL_URL + "clip/999x999/" + self.hero.name
+                return get_thumbnail_url(index) + "clip/999x999/" + self.hero.name
             else:
                 return None
         else:
-            return settings.THUMBNAIL_URL + "clip/999x999/" + self.hero.name
+            return get_thumbnail_url(index) + "clip/999x999/" + self.hero.name
 
     push_to_s3 = ['hero', 'lockup_derivative', 'alternate_lockup_derivative']
     def save(self, *args, **kwargs):
@@ -274,13 +285,13 @@ class HistoricalEssay(models.Model):
 
     def lockup(self, index):
         if self.hero_first:
-            return settings.THUMBNAIL_URL + "crop/298x121/" + self.hero.name
+            return get_thumbnail_url(index) + "crop/298x121/" + self.hero.name
         else:
             reference_image_md5 = get_reference_image_md5(self.item_id, index)
             if reference_image_md5:
-               return settings.THUMBNAIL_URL + "crop/298x121/" +  reference_image_md5
+               return get_thumbnail_url(index) + "crop/298x121/" +  reference_image_md5
             elif self.hero:
-                return settings.THUMBNAIL_URL + "crop/298x121/" + self.hero.name
+                return get_thumbnail_url(index) + "crop/298x121/" + self.hero.name
             else:
                 return None
 
@@ -288,13 +299,13 @@ class HistoricalEssay(models.Model):
         if self.item_id:
             reference_image_md5 = get_reference_image_md5(self.item_id, index)
             if reference_image_md5:
-               return settings.THUMBNAIL_URL + "clip/999x999/" +  reference_image_md5
+               return get_thumbnail_url(index) + "clip/999x999/" +  reference_image_md5
             elif self.hero:
-                return settings.THUMBNAIL_URL + "clip/999x999/" + self.hero.name
+                return get_thumbnail_url(index) + "clip/999x999/" + self.hero.name
             else:
                 return None
         else:
-            return settings.THUMBNAIL_URL + "clip/999x999/" + self.hero.name
+            return get_thumbnail_url(index) + "clip/999x999/" + self.hero.name
 
     def __str__(self):
         return self.title
@@ -352,21 +363,21 @@ class LessonPlan(models.Model):
 
     def lockup(self, index):
         if self.lockup_derivative:
-            return settings.THUMBNAIL_URL + "crop/298x121/" + self.lockup_derivative.name
+            return get_thumbnail_url(index) + "crop/298x121/" + self.lockup_derivative.name
         else:
             reference_image_md5 = get_reference_image_md5(self.item_id, index)
             if reference_image_md5:
-               return settings.THUMBNAIL_URL + "crop/298x121/" +  reference_image_md5
+               return get_thumbnail_url(index) + "crop/298x121/" +  reference_image_md5
             else:
                 return None
 
     def social_media_card(self, index):
         if self.lockup_derivative:
-            return settings.THUMBNAIL_URL + "clip/999x999/" + self.lockup_derivative.name
+            return get_thumbnail_url(index) + "clip/999x999/" + self.lockup_derivative.name
         else:
             reference_image_md5 = get_reference_image_md5(self.item_id, index)
             if reference_image_md5:
-               return settings.THUMBNAIL_URL + "clip/999x999/" +  reference_image_md5
+               return get_thumbnail_url(index) + "clip/999x999/" +  reference_image_md5
             else:
                 return None
 
@@ -453,15 +464,15 @@ class Theme(models.Model):
 
     def theme_lockup(self, index):
         if self.lockup_derivative:
-            return settings.THUMBNAIL_URL + "crop/420x210/" + self.lockup_derivative.name
+            return get_thumbnail_url(index) + "crop/420x210/" + self.lockup_derivative.name
         elif self.hero_first:
-            return settings.THUMBNAIL_URL + "crop/420x210/" + self.hero.name
+            return get_thumbnail_url(index) + "crop/420x210/" + self.hero.name
         else:
             reference_image_md5 = get_reference_image_md5(self.item_id, index)
             if reference_image_md5:
-               return settings.THUMBNAIL_URL + "crop/420x210/" +  reference_image_md5
+               return get_thumbnail_url(index) + "crop/420x210/" +  reference_image_md5
             elif self.hero:
-                return settings.THUMBNAIL_URL + "crop/420x210/" + self.hero.name
+                return get_thumbnail_url(index) + "crop/420x210/" + self.hero.name
             else:
                 return None
 
@@ -486,13 +497,13 @@ class Theme(models.Model):
         if self.item_id:
             reference_image_md5 = get_reference_image_md5(self.item_id, index)
             if reference_image_md5:
-               return settings.THUMBNAIL_URL + "clip/999x999/" +  reference_image_md5
+               return get_thumbnail_url(index) + "clip/999x999/" +  reference_image_md5
             elif self.hero:
-                return settings.THUMBNAIL_URL + "clip/999x999/" + self.hero.name
+                return get_thumbnail_url(index) + "clip/999x999/" + self.hero.name
             else:
                 return None
         else:
-            return settings.THUMBNAIL_URL + "clip/999x999/" + self.hero.name
+            return get_thumbnail_url(index) + "clip/999x999/" + self.hero.name
 
     def __str__(self):
         return self.title
@@ -565,11 +576,11 @@ class ExhibitItem(models.Model):
 
     def imgUrl(self, index):
         if self.custom_crop:
-            return settings.THUMBNAIL_URL + "crop/210x210/" + self.custom_crop.name
+            return get_thumbnail_url(index) + "crop/210x210/" + self.custom_crop.name
         else:
             reference_image_md5 = get_reference_image_md5(self.item_id, index)
             if reference_image_md5:
-               return settings.THUMBNAIL_URL + "crop/210x210/" +  reference_image_md5
+               return get_thumbnail_url(index) + "crop/210x210/" +  reference_image_md5
             else:
                 return None
 

--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -62,6 +62,14 @@ def getRepositoryData(repository_data):
 
     return repository
 
+def get_reference_image_md5(item_id):
+    item_id_search_term = 'id:"{0}"'.format(item_id)
+    item_solr_search = SOLR_select(q=item_id_search_term)
+    if len(item_solr_search.results) > 0 and 'reference_image_md5' in item_solr_search.results[0]:
+        return item_solr_search.results[0]['reference_image_md5']
+    else:
+        return None
+
 # class ImageArk(models.Model):
 #     hero = models.ImageField(blank=True, verbose_name='Hero Image', upload_to='uploads/')
 #     lockup_derivative = models.ImageField(blank=True, verbose_name='Lockup Image', upload_to='uploads/')
@@ -138,10 +146,9 @@ class Exhibit(models.Model):
         elif self.hero_first:
             return settings.THUMBNAIL_URL + "crop/273x182/" + self.hero.name
         else:
-            item_id_search_term = 'id:"{0}"'.format(self.item_id)
-            item_solr_search = SOLR_select(q=item_id_search_term)
-            if len(item_solr_search.results) > 0 and 'reference_image_md5' in item_solr_search.results[0]:
-                return settings.THUMBNAIL_URL + "crop/273x182/" + item_solr_search.results[0]['reference_image_md5']
+            reference_image_md5 = get_reference_image_md5(self.item_id)
+            if reference_image_md5:
+                return settings.THUMBNAIL_URL + "crop/273x182/" + reference_image_md5
             elif self.hero:
                 return settings.THUMBNAIL_URL + "crop/273x182/" + self.hero.name
             else:
@@ -151,10 +158,9 @@ class Exhibit(models.Model):
         if self.hero_first:
             return settings.THUMBNAIL_URL + "crop/298x121/" + self.hero.name
         else:
-            item_id_search_term = 'id:"{0}"'.format(self.item_id)
-            item_solr_search = SOLR_select(q=item_id_search_term)
-            if len(item_solr_search.results) > 0 and 'reference_image_md5' in item_solr_search.results[0]:
-                return settings.THUMBNAIL_URL + "crop/298x121/" + item_solr_search.results[0]['reference_image_md5']
+            reference_image_md5 = get_reference_image_md5(self.item_id)
+            if reference_image_md5:
+               return settings.THUMBNAIL_URL + "crop/298x121/" +  reference_image_md5
             elif self.hero:
                 return settings.THUMBNAIL_URL + "crop/298x121/" + self.hero.name
             else:
@@ -162,10 +168,9 @@ class Exhibit(models.Model):
 
     def social_media_card(self):
         if self.item_id:
-            item_id_search_term = 'id:"{0}"'.format(self.item_id)
-            item_solr_search = SOLR_select(q=item_id_search_term)
-            if len(item_solr_search.results) > 0 and 'reference_image_md5' in item_solr_search.results[0]:
-                return settings.THUMBNAIL_URL + "clip/999x999/" + item_solr_search.results[0]['reference_image_md5']
+            reference_image_md5 = get_reference_image_md5(self.item_id)
+            if reference_image_md5:
+               return settings.THUMBNAIL_URL + "clip/999x999/" +  reference_image_md5
             elif self.hero:
                 return settings.THUMBNAIL_URL + "clip/999x999/" + self.hero.name
             else:
@@ -264,10 +269,9 @@ class HistoricalEssay(models.Model):
         if self.hero_first:
             return settings.THUMBNAIL_URL + "crop/298x121/" + self.hero.name
         else:
-            item_id_search_term = 'id:"{0}"'.format(self.item_id)
-            item_solr_search = SOLR_select(q=item_id_search_term)
-            if len(item_solr_search.results) > 0 and 'reference_image_md5' in item_solr_search.results[0]:
-                return settings.THUMBNAIL_URL + "crop/298x121/" + item_solr_search.results[0]['reference_image_md5']
+            reference_image_md5 = get_reference_image_md5(self.item_id)
+            if reference_image_md5:
+               return settings.THUMBNAIL_URL + "crop/298x121/" +  reference_image_md5
             elif self.hero:
                 return settings.THUMBNAIL_URL + "crop/298x121/" + self.hero.name
             else:
@@ -275,10 +279,9 @@ class HistoricalEssay(models.Model):
 
     def social_media_card(self):
         if self.item_id:
-            item_id_search_term = 'id:"{0}"'.format(self.item_id)
-            item_solr_search = SOLR_select(q=item_id_search_term)
-            if len(item_solr_search.results) > 0 and 'reference_image_md5' in item_solr_search.results[0]:
-                return settings.THUMBNAIL_URL + "clip/999x999/" + item_solr_search.results[0]['reference_image_md5']
+            reference_image_md5 = get_reference_image_md5(self.item_id)
+            if reference_image_md5:
+               return settings.THUMBNAIL_URL + "clip/999x999/" +  reference_image_md5
             elif self.hero:
                 return settings.THUMBNAIL_URL + "clip/999x999/" + self.hero.name
             else:
@@ -344,10 +347,9 @@ class LessonPlan(models.Model):
         if self.lockup_derivative:
             return settings.THUMBNAIL_URL + "crop/298x121/" + self.lockup_derivative.name
         else:
-            item_id_search_term = 'id:"{0}"'.format(self.item_id)
-            item_solr_search = SOLR_select(q=item_id_search_term)
-            if len(item_solr_search.results) > 0 and 'reference_image_md5' in item_solr_search.results[0]:
-                return settings.THUMBNAIL_URL + "crop/298x121/" + item_solr_search.results[0]['reference_image_md5']
+            reference_image_md5 = get_reference_image_md5(self.item_id)
+            if reference_image_md5:
+               return settings.THUMBNAIL_URL + "crop/298x121/" +  reference_image_md5
             else:
                 return None
 
@@ -355,10 +357,9 @@ class LessonPlan(models.Model):
         if self.lockup_derivative:
             return settings.THUMBNAIL_URL + "clip/999x999/" + self.lockup_derivative.name
         else:
-            item_id_search_term = 'id:"{0}"'.format(self.item_id)
-            item_solr_search = SOLR_select(q=item_id_search_term)
-            if len(item_solr_search.results) > 0 and 'reference_image_md5' in item_solr_search.results[0]:
-                return settings.THUMBNAIL_URL + "clip/999x999/" + item_solr_search.results[0]['reference_image_md5']
+            reference_image_md5 = get_reference_image_md5(self.item_id)
+            if reference_image_md5:
+               return settings.THUMBNAIL_URL + "clip/999x999/" +  reference_image_md5
             else:
                 return None
 
@@ -449,10 +450,9 @@ class Theme(models.Model):
         elif self.hero_first:
             return settings.THUMBNAIL_URL + "crop/420x210/" + self.hero.name
         else:
-            item_id_search_term = 'id:"{0}"'.format(self.item_id)
-            item_solr_search = SOLR_select(q=item_id_search_term)
-            if len(item_solr_search.results) > 0 and 'reference_image_md5' in item_solr_search.results[0]:
-                return settings.THUMBNAIL_URL + "crop/420x210/" + item_solr_search.results[0]['reference_image_md5']
+            reference_image_md5 = get_reference_image_md5(self.item_id)
+            if reference_image_md5:
+               return settings.THUMBNAIL_URL + "crop/420x210/" +  reference_image_md5
             elif self.hero:
                 return settings.THUMBNAIL_URL + "crop/420x210/" + self.hero.name
             else:
@@ -477,10 +477,9 @@ class Theme(models.Model):
 
     def social_media_card(self):
         if self.item_id:
-            item_id_search_term = 'id:"{0}"'.format(self.item_id)
-            item_solr_search = SOLR_select(q=item_id_search_term)
-            if len(item_solr_search.results) > 0 and 'reference_image_md5' in item_solr_search.results[0]:
-                return settings.THUMBNAIL_URL + "clip/999x999/" + item_solr_search.results[0]['reference_image_md5']
+            reference_image_md5 = get_reference_image_md5(self.item_id)
+            if reference_image_md5:
+               return settings.THUMBNAIL_URL + "clip/999x999/" +  reference_image_md5
             elif self.hero:
                 return settings.THUMBNAIL_URL + "clip/999x999/" + self.hero.name
             else:
@@ -556,10 +555,9 @@ class ExhibitItem(models.Model):
         if self.custom_crop:
             return settings.THUMBNAIL_URL + "crop/210x210/" + self.custom_crop.name
         else:
-            item_id_search_term = 'id:"{0}"'.format(self.item_id)
-            item_solr_search = SOLR_select(q=item_id_search_term)
-            if len(item_solr_search.results) > 0 and 'reference_image_md5' in item_solr_search.results[0]:
-                return settings.THUMBNAIL_URL + "crop/210x210/" + item_solr_search.results[0]['reference_image_md5']
+            reference_image_md5 = get_reference_image_md5(self.item_id)
+            if reference_image_md5:
+               return settings.THUMBNAIL_URL + "crop/210x210/" +  reference_image_md5
             else:
                 return None
 

--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -64,9 +64,14 @@ def getRepositoryData(repository_data):
 
     return repository
 
-def get_reference_image_md5(item_id):
+def get_reference_image_md5(item_id, index='solr'):
     item_id_search_term = 'id:"{0}"'.format(item_id)
-    item_search = SOLR_get(q=item_id_search_term)
+    item_search = None
+    if index == 'solr':
+        item_search = SOLR_get(q=item_id_search_term)
+    elif index == 'es':
+        item_search = es_get(item_id)
+
     if item_search and 'reference_image_md5' in item_search.item:
         return item_search.item['reference_image_md5']
     else:
@@ -535,9 +540,14 @@ class ExhibitItem(models.Model):
     def __str__(self):
         return self.item_id
 
-    def indexedData(self):
+    def indexedData(self, index='solr'):
         item_id_search_term = 'id:"{0}"'.format(self.item_id)
-        item_search = SOLR_get(q=item_id_search_term)
+        item_search = None
+        if index == 'solr':
+            item_search = SOLR_get(q=item_id_search_term)
+        elif index == 'es':
+            item_search = es_get(self.item_id)
+
         if item_search:
             item = item_search.item
 

--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -535,7 +535,7 @@ class ExhibitItem(models.Model):
     def __str__(self):
         return self.item_id
 
-    def solrData(self):
+    def indexedData(self):
         item_id_search_term = 'id:"{0}"'.format(self.item_id)
         item_search = SOLR_get(q=item_id_search_term)
         if item_search:

--- a/exhibits/templates/exhibits/calCultures.html
+++ b/exhibits/templates/exhibits/calCultures.html
@@ -1,5 +1,6 @@
 {% extends exhibitBaseTemplate|pjax_available:request %}
 {% load markdown_filter %}
+{% load lockups %}
 
 {% if calisphere %}
   {% block page-metadata %}
@@ -32,7 +33,7 @@
             <a href="{{ theme.get_absolute_url }}" data-pjax="js-pageContent">
               <div class="exhibit__lockup--med">
                 <div class="exhibit__lockup--med-image">
-                  <div class="aspect-ratio-content exhibit__lockup--med-image-content" style="background-image: url('{{ theme.theme_lockup }}');">
+                  <div class="aspect-ratio-content exhibit__lockup--med-image-content" style="background-image: url('{% theme_lockup theme request.session.index %}');">
                   </div>
                 </div>
                 <div class="exhibit__lockup--med-title">
@@ -54,7 +55,7 @@
         <div class="col-xs-2 col-md-3">
           <a href="{{ he.get_absolute_url }}">
             <div class="exhibit__essay-lockup">
-              <div class="aspect-ratio-content exhibit__essay-lockup-image" style="background-image: url({{ he.lockup }});">
+              <div class="aspect-ratio-content exhibit__essay-lockup-image" style="background-image: url({% lockup_image he request.session.index %});">
                 <div class="exhibit__essay-lockup-color"></div>
                 <div class="exhibit__essay-lockup-title">{{ he.title }}</div>
               </div>
@@ -72,7 +73,7 @@
         <div class="col-xs-2 col-md-3">
           <a href="{{ lp.get_absolute_url }}">
             <div class="exhibit__lesson-lockup">
-              <div class="aspect-ratio-content exhibit__lesson-lockup-image" style="background-image: url({{ lp.lockup }});">
+              <div class="aspect-ratio-content exhibit__lesson-lockup-image" style="background-image: url({% lockup_image lp request.session.index %});">
                 <div class="exhibit__lesson-lockup-color"></div>
                 <div class="exhibit__lesson-lockup-title">{{ lp.title }}:<br/>{{ lp.sub_title }}</div>
               </div>

--- a/exhibits/templates/exhibits/essayView.html
+++ b/exhibits/templates/exhibits/essayView.html
@@ -1,9 +1,11 @@
 {% extends exhibitBaseTemplate|pjax_available:request %}
 {% load markdown_filter %}
+{% load lockups %}
 
 {% if calisphere %}
   {% block page-metadata %}
-    {% include "calisphere/microdata.html" with title=essay.title description="Calisphere supports classroom activities and research efforts for students from elementary school through higher education. Essays explore the history of California and the state's evolving diversity." meta_image=essay.social_media_card %}
+    {% social_media_card essay request.session.index as social_card %}
+    {% include "calisphere/microdata.html" with title=essay.title description="Calisphere supports classroom activities and research efforts for students from elementary school through higher education. Essays explore the history of California and the state's evolving diversity." meta_image=social_card  %}
   {% endblock %}
 {% endif %}
 

--- a/exhibits/templates/exhibits/exhibitDirectory.html
+++ b/exhibits/templates/exhibits/exhibitDirectory.html
@@ -1,5 +1,6 @@
 {% extends exhibitBaseTemplate|pjax_available:request %}
 {% load markdown_filter %}
+{% load lockups %}
 
 {% if calisphere %}
   {% block page-metadata %}
@@ -44,7 +45,7 @@
             <a href="{{ exhibit.get_absolute_url }}" data-pjax="js-pageContent">
               <div class="exhibit__lockup--med">
                 <div class="exhibit__lockup--med-image">
-                  <div class="aspect-ratio-content exhibit__lockup--med-image-content" style="background-image: url('{{ exhibit.exhibit_lockup }}');">
+                  <div class="aspect-ratio-content exhibit__lockup--med-image-content" style="background-image: url('{% exhibit_lockup exhibit request.session.index %}');">
                   </div>
                 </div>
                 <div class="exhibit__lockup--med-title">
@@ -59,7 +60,7 @@
             <a href="{{ theme.get_absolute_url }}" data-pjax="js-pageContent">
               <div class="theme__lockup--horizontal">
                 <div class="theme__lockup--horizontal-image">
-                  <div class="aspect-ratio-content theme__lockup--horizontal-image-content" style="background-image: url('{{ theme.theme_lockup }}');">
+                  <div class="aspect-ratio-content theme__lockup--horizontal-image-content" style="background-image: url('{% theme_lockup theme request.session.index %}');">
                   <div class="theme__lockup--horizontal-color" style="background-color: {{ theme.color }}"></div>
                   <div class="theme__lockup--horizontal-title">
                       {{ theme.title }}

--- a/exhibits/templates/exhibits/exhibitRandomExplore.html
+++ b/exhibits/templates/exhibits/exhibitRandomExplore.html
@@ -1,5 +1,6 @@
 {% extends exhibitBaseTemplate|pjax_available:request %}
 {% load markdown_filter %}
+{% load lockups %}
 
 {% if calisphere %}
   {% block page-metadata %}
@@ -20,7 +21,7 @@
           <a href="{{ entry.get_absolute_url }}" data-pjax="js-pageContent">
             <div class="exhibit__lockup--med">
               <div class="exhibit__lockup--med-image">
-                <div class="aspect-ratio-content exhibit__lockup--med-image-content" style="background-image: url('{{ entry.exhibit_lockup }}');">
+                <div class="aspect-ratio-content exhibit__lockup--med-image-content" style="background-image: url('{% exhibit_lockup entry request.session.index %}');">
                 </div>
               </div>
               <div class="exhibit__lockup--med-title">
@@ -34,7 +35,7 @@
           <a href="{{ entry.get_absolute_url }}" data-pjax="js-pageContent">
             <div class="theme__lockup--horizontal">
               <div class="theme__lockup--horizontal-image">
-                <div class="aspect-ratio-content theme__lockup--horizontal-image-content" style="background-image: url('{{ entry.theme_lockup }}');">
+                <div class="aspect-ratio-content theme__lockup--horizontal-image-content" style="background-image: url('{% theme_lockup entry request.session.index %}');">
                   <div class="theme__lockup--horizontal-color" style="background-color: {{ entry.color }}"></div>
                   <div class="theme__lockup--horizontal-title">
                     {{ entry.title }}

--- a/exhibits/templates/exhibits/exhibitSearch.html
+++ b/exhibits/templates/exhibits/exhibitSearch.html
@@ -1,5 +1,6 @@
 {% extends exhibitBaseTemplate|pjax_available:request %}
 {% load markdown_filter %}
+{% load lockups %}
 
 {% if calisphere %}
   {% block page-metadata %}
@@ -31,7 +32,7 @@
       <a href="{{ exhibit.get_absolute_url }}" data-pjax="js-pageContent">
         <div class="exhibit__lockup--med">
           <div class="exhibit__lockup--med-image">
-            <div class="aspect-ratio-content exhibit__lockup--med-image-content" style="background-image: url('{{ exhibit.exhibit_lockup }}');">
+            <div class="aspect-ratio-content exhibit__lockup--med-image-content" style="background-image: url('{% exhibit_lockup exhibit request.session.index %}');">
             </div>
           </div>
           <div class="exhibit__lockup--med-title">

--- a/exhibits/templates/exhibits/exhibitView.html
+++ b/exhibits/templates/exhibits/exhibitView.html
@@ -1,9 +1,11 @@
 {% extends exhibitBaseTemplate|pjax_available:request %}
 {% load markdown_filter %}
+{% load lockups %}
 
 {% if calisphere %}
   {% block page-metadata %}
-    {% include "calisphere/microdata.html" with title=exhibit.title description=exhibit.blockquote meta_image=exhibit.social_media_card %}
+    {% social_media_card exhibit request.session.index as social_card %}
+    {% include "calisphere/microdata.html" with title=exhibit.title description=exhibit.blockquote meta_image=social_card %}
   {% endblock %}
 {% endif %}
 
@@ -116,7 +118,7 @@
               <a href="{{ exhibit.exhibit.get_absolute_url }}" data-pjax="js-pageContent">
                 <div class="exhibit__lockup--med">
                   <div class="exhibit__lockup--med-image">
-                    <div class="aspect-ratio-content exhibit__lockup--med-image-content" style="background-image: url('{{ exhibit.exhibit.exhibit_lockup }}');">
+                    <div class="aspect-ratio-content exhibit__lockup--med-image-content" style="background-image: url('{% exhibit_lockup exhibit.exhibit request.session.index %}');">
                     </div>
                   </div>
                   <div class="exhibit__lockup--med-title">
@@ -138,7 +140,7 @@
         <div class="col-xs-2 col-md-3">
           <a href="{{ hee.historicalEssay.get_absolute_url }}" data-pjax="js-pageContent">
             <div class="exhibit__essay-lockup">
-              <div class="aspect-ratio-content exhibit__essay-lockup-image" style="background-image: url({{ hee.historicalEssay.lockup }});">
+              <div class="aspect-ratio-content exhibit__essay-lockup-image" style="background-image: url({% lockup_image hee.historicalEssay request.session.index %});">
                 <div class="exhibit__essay-lockup-color"></div>
                 <div class="exhibit__essay-lockup-title">{{ hee.historicalEssay.title }}</div>
               </div>
@@ -156,7 +158,7 @@
         <div class="col-xs-2 col-md-3">
           <a href="{{ lpe.lessonPlan.get_absolute_url }}" data-pjax="js-pageContent">
             <div class="exhibit__lesson-lockup">
-              <div class="aspect-ratio-content exhibit__lesson-lockup-image" style="background-image: url({{ lpe.lessonPlan.lockup }});">
+              <div class="aspect-ratio-content exhibit__lesson-lockup-image" style="background-image: url({% lockup_image lpe.lessonPlan request.session.index %});">
                 <div class="exhibit__lesson-lockup-color"></div>
                 <div class="exhibit__lesson-lockup-title">{{ lpe.lessonPlan.title }}:<br/>{{ lpe.lessonPlan.sub_title }}</div>
               </div>

--- a/exhibits/templates/exhibits/exhibit_items.html
+++ b/exhibits/templates/exhibits/exhibit_items.html
@@ -1,6 +1,6 @@
 <div class="row primarysource">
   {% for item in exhibitItems %}
-    {% with item.solrData as exhibitItemData %}
+    {% with item.indexedData as exhibitItemData %}
     <div class="col-xs-6 col-sm-3 col-md-2">
         <a class="primarysource__link js-exhibit-item" href="{% url url_name url_id item.item_id %}" title="{% if exhibitItemData %}{{ exhibitItemData.title.0 }}{% else %}{{ item.custom_title }}{% endif %}">
 
@@ -46,7 +46,7 @@
             {% elif item.custom_title %}
               {{ item.custom_title }}
             {% else %}
-              {{ item.item_id }} not in Calisphere solr index
+              {{ item.item_id }} not in Calisphere search index
             {% endif %}
           </div>
         </div>

--- a/exhibits/templates/exhibits/exhibit_items.html
+++ b/exhibits/templates/exhibits/exhibit_items.html
@@ -1,6 +1,7 @@
+{% load lockups %}
 <div class="row primarysource">
   {% for item in exhibitItems %}
-    {% with item.indexedData as exhibitItemData %}
+    {% indexed_data item request.session.index as exhibitItemData %}
     <div class="col-xs-6 col-sm-3 col-md-2">
         <a class="primarysource__link js-exhibit-item" href="{% url url_name url_id item.item_id %}" title="{% if exhibitItemData %}{{ exhibitItemData.title.0 }}{% else %}{{ item.custom_title }}{% endif %}">
 
@@ -52,7 +53,6 @@
         </div>
         </a>
     </div>
-    {% endwith %}
     {% if forloop.counter == 12 %}
       <div class="js-exhibit-items-overflow hidden-content" style="width: 100%;">
     {% endif %}

--- a/exhibits/templates/exhibits/itemView.html
+++ b/exhibits/templates/exhibits/itemView.html
@@ -1,8 +1,10 @@
 {% extends "exhibits/exhibitView.html,exhibits/pjaxTemplates/pjax-exhibit-item.html"|pjax_available:request %}
+{% load lockups %}
 
 {% if calisphere %}
 	{% block page-metadata %}
-		{% include "calisphere/microdata.html" with title=exhibit.title description=exhibit.blockquote meta_image=exhibit.social_media_card meta_robots="noindex,follow" %}
+		{% social_media_card exhibit request.session.index as social_card %}
+		{% include "calisphere/microdata.html" with title=exhibit.title description=exhibit.blockquote meta_image=social_card meta_robots="noindex,follow" %}
 	{% endblock %}
 {% endif %}
 

--- a/exhibits/templates/exhibits/item_content.html
+++ b/exhibits/templates/exhibits/item_content.html
@@ -1,5 +1,6 @@
 {% load markdown_filter %}
 {% load exhibit_extras %}
+{% load lockups %}
 
 <div class="exhibit__modal">
   {% if prevItem %}
@@ -18,7 +19,7 @@
 
   <div class="exhibit__modal-content-wrapper">
   {% with clipto="500x500" %}
-  {% with item=exhibitItem.indexedData %}
+  {% indexed_data exhibitItem request.session.index as item %}
   {% if item %}
     <div class="exhibit__modal-content">
       <div class="obj-container__simple-{% if 'reference_image_md5' in item %}image{% else %}tile{% endif %}">
@@ -161,7 +162,6 @@
       </div>
     </div>
   {% endif %}
-  {% endwith %}
   {% endwith %}
   </div>
 

--- a/exhibits/templates/exhibits/item_content.html
+++ b/exhibits/templates/exhibits/item_content.html
@@ -18,7 +18,7 @@
 
   <div class="exhibit__modal-content-wrapper">
   {% with clipto="500x500" %}
-  {% with item=exhibitItem.solrData %}
+  {% with item=exhibitItem.indexedData %}
   {% if item %}
     <div class="exhibit__modal-content">
       <div class="obj-container__simple-{% if 'reference_image_md5' in item %}image{% else %}tile{% endif %}">

--- a/exhibits/templates/exhibits/lessonPlanView.html
+++ b/exhibits/templates/exhibits/lessonPlanView.html
@@ -1,9 +1,11 @@
 {% extends exhibitBaseTemplate|pjax_available:request %}
 {% load markdown_filter %}
+{% load lockups %}
 
 {% if calisphere %}
   {% block page-metadata %}
-    {% include "calisphere/microdata.html" with title=lessonPlan.title description='Calisphere supports classroom activities and research efforts for students from elementary school through higher education. Use these lesson plans just as they are, or as springboards for your own creative ideas.' meta_image=lessonPlan.social_media_card %}
+    {% social_media_card lessonPlan request.session.index as social_card %}
+    {% include "calisphere/microdata.html" with title=lessonPlan.title description='Calisphere supports classroom activities and research efforts for students from elementary school through higher education. Use these lesson plans just as they are, or as springboards for your own creative ideas.' meta_image=social_card %}
   {% endblock %}
 {% endif %}
 
@@ -90,7 +92,7 @@
             <a href="{{ lpe.exhibit.get_absolute_url }}" data-pjax="js-pageContent">
               <div class="exhibit__lockup--med">
                 <div class="exhibit__lockup--med-image">
-                  <div class="aspect-ratio-content exhibit__lockup--med-image-content" style="background-image: url('{{ lpe.exhibit.exhibit_lockup }}');">
+                  <div class="aspect-ratio-content exhibit__lockup--med-image-content" style="background-image: url('{% exhibit_lockup lpe.exhibit request.session.index }');">
                   </div>
                 </div>
                 <div class="exhibit__lockup--med-title">
@@ -113,7 +115,7 @@
             <div class="col-xs-2 col-md-3">
               <a href="{{ lp.lessonPlan.get_absolute_url }}" data-pjax="js-pageContent">
                 <div class="exhibit__lesson-lockup">
-                  <div class="aspect-ratio-content exhibit__lesson-lockup-image" style="background-image: url({{ lp.lessonPlan.lockup }});">
+                  <div class="aspect-ratio-content exhibit__lesson-lockup-image" style="background-image: url({% lockup_image lp.lessonPlan request.session.index %});">
                     <div class="exhibit__lesson-lockup-color"></div>
                     <div class="exhibit__lesson-lockup-title">{{ lp.lessonPlan }}</div>
                   </div>

--- a/exhibits/templates/exhibits/themeView.html
+++ b/exhibits/templates/exhibits/themeView.html
@@ -1,9 +1,11 @@
 {% extends exhibitBaseTemplate|pjax_available:request %}
 {% load markdown_filter %}
+{% load lockups %}
 
 {% if calisphere %}
   {% block page-metadata %}
-    {% include "calisphere/microdata.html" with title=theme.title meta_image=theme.social_media_card %}
+    {% social_media_card theme request.session.index as social_card %}
+    {% include "calisphere/microdata.html" with title=theme.title meta_image=social_card %}
   {% endblock %}
 {% endif %}
 
@@ -33,7 +35,7 @@
             <a href="{{ exhibittheme.exhibit.get_absolute_url }}" data-pjax="js-pageContent">
               <div class="exhibit__lockup--med">
                 <div class="exhibit__lockup--med-image">
-                  <div class="aspect-ratio-content exhibit__lockup--med-image-content" style="background-image: url('{{ exhibittheme.exhibit.exhibit_lockup }}');">
+                  <div class="aspect-ratio-content exhibit__lockup--med-image-content" style="background-image: url('{% exhibit_lockup exhibittheme.exhibit request.session.index %}');">
                   </div>
                 </div>
                 <div class="exhibit__lockup--med-title">
@@ -55,7 +57,7 @@
         <div class="col-xs-2 col-md-3">
           <a href="{{ het.historicalEssay.get_absolute_url }}" data-pjax="js-pageContent">
             <div class="exhibit__essay-lockup">
-              <div class="aspect-ratio-content exhibit__essay-lockup-image" style="background-image: url({{ het.historicalEssay.lockup }});">
+              <div class="aspect-ratio-content exhibit__essay-lockup-image" style="background-image: url({% lockup_image het.historicalEssay request.session.index %});">
                 <div class="exhibit__essay-lockup-color"></div>
                 <div class="exhibit__essay-lockup-title">{{ het.historicalEssay.title }}</div>
               </div>
@@ -73,7 +75,7 @@
         <div class="col-xs-2 col-md-3">
           <a href="{{ lpt.lessonPlan.get_absolute_url }}" data-pjax="js-pageContent">
             <div class="exhibit__lesson-lockup">
-              <div class="aspect-ratio-content exhibit__lesson-lockup-image" style="background-image: url({{ lpt.lessonPlan.lockup }});">
+              <div class="aspect-ratio-content exhibit__lesson-lockup-image" style="background-image: url({% lockup_image lpt.lessonPlan request.session.index %});">
                 <div class="exhibit__lesson-lockup-color"></div>
                 <div class="exhibit__lesson-lockup-title">{{ lpt.lessonPlan.title }}:<br/>{{ lpt.lessonPlan.sub_title }}</div>
               </div>

--- a/exhibits/templatetags/lockups.py
+++ b/exhibits/templatetags/lockups.py
@@ -1,0 +1,33 @@
+from django import template
+
+register = template.Library()
+
+@register.simple_tag
+# Exhibit
+def exhibit_lockup(exhibit, *args):
+    return exhibit.exhibit_lockup(*args)
+
+@register.simple_tag
+# Exhibit; unused
+def exhibit_lockup_sm(exhibit, *args):
+    return exhibit.exhibit_lockup_sm(*args)
+
+@register.simple_tag
+# Exhibit, HistoricalEssay, LessonPlan, Theme
+def social_media_card(obj, *args):
+    return obj.social_media_card(*args)
+
+@register.simple_tag
+# HistoricalEssay, LessonPlan
+def lockup_image(obj, *args):
+    return obj.lockup(*args)
+
+@register.simple_tag
+def theme_lockup(theme, *args):
+    return theme.theme_lockup(*args)
+
+@register.simple_tag
+def indexed_data(exhibit_item, *args):
+    return exhibit_item.indexedData(*args)
+
+# TODO: ALSO NEED TO IMPORT CUSTOM TEMPLATE TAGS EVERYWHERE THEY ARE USED

--- a/exhibits/utils.py
+++ b/exhibits/utils.py
@@ -9,7 +9,6 @@ from retrying import retry
 from django.core.cache import cache
 from django.conf import settings
 from functools import wraps
-from django.utils.decorators import available_attrs
 from django.views.decorators.cache import cache_page
 
 
@@ -36,7 +35,7 @@ def json_loads_url(url_or_req):
 
 # https://stackoverflow.com/questions/27347921/in-django-can-per-view-cache-decorator-be-session-dependent-for-a-b-testings
 def cache_by_session_state(func):
-    @wraps(func, assigned=available_attrs(func))
+    @wraps(func)
     def wrapper(request, *args, **kwargs):
         index = request.session.get('index')
 

--- a/exhibits/utils.py
+++ b/exhibits/utils.py
@@ -1,0 +1,57 @@
+import pickle
+import hashlib
+import json
+import urllib.request
+import urllib.error
+import urllib.parse
+
+from retrying import retry
+from django.core.cache import cache
+from django.conf import settings
+from functools import wraps
+from django.utils.decorators import available_attrs
+from django.views.decorators.cache import cache_page
+
+
+# create a hash for a cache key
+def kwargs_md5(**kwargs):
+    m = hashlib.md5()
+    m.update(pickle.dumps(kwargs))
+    return m.hexdigest()
+
+
+# wrapper function for json.loads(urllib2.urlopen)
+@retry(wait_exponential_multiplier=2, stop_max_delay=10000)  # milliseconds
+def json_loads_url(url_or_req):
+    key = kwargs_md5(key='json_loads_url', url=url_or_req)
+    data = cache.get(key)
+    if not data:
+        try:
+            data = json.loads(
+                urllib.request.urlopen(url_or_req).read().decode('utf-8'))
+        except urllib.error.HTTPError:
+            data = {}
+    return data
+
+
+# https://stackoverflow.com/questions/27347921/in-django-can-per-view-cache-decorator-be-session-dependent-for-a-b-testings
+def cache_by_session_state(func):
+    @wraps(func, assigned=available_attrs(func))
+    def wrapper(request, *args, **kwargs):
+        index = request.session.get('index')
+
+        if (
+            not index or
+            (index == 'solr' and not settings.SOLR_URL) or
+            (index == 'es' and not settings.ES_HOST)
+        ):
+            # no index happens when we have a first-time visitor;
+            # index variables without corresponding settings variables
+            # can happen in development when there's a persistent
+            # browser session across a change in settings configuration
+            index = settings.DEFAULT_INDEX
+            request.session['index'] = index
+
+        cached = cache_page(60 * 1, key_prefix=index)(func)
+        return cached(request, *args, **kwargs)
+    return wrapper

--- a/exhibits/views.py
+++ b/exhibits/views.py
@@ -10,7 +10,9 @@ from django.conf import settings
 from exhibits.cache_retry import SOLR_get_list
 import random
 import json
+from exhibits.utils import cache_by_session_state
 
+@cache_by_session_state
 def calCultures(request):
     california_cultures = Theme.objects.filter(title__icontains='California Cultures').order_by('title')
 
@@ -30,6 +32,7 @@ def calCultures(request):
         'lesson_plans': lesson_plans
     })
 
+@cache_by_session_state
 def exhibitRandom(request):
     exhibits = Exhibit.objects.all()
     themes = Theme.objects.all()
@@ -79,6 +82,7 @@ def exhibitRandom(request):
 
     return render(request, 'exhibits/exhibitRandomExplore.html', {'sets': exhibit_theme_list_by_fives, 'sets_standard': exhibit_theme_list})
 
+@cache_by_session_state
 def exhibitSearch(request):
     if request.method == 'GET' and len(request.GET.getlist('title')) > 0:
         exhibits = Exhibit.objects.filter(title__icontains=request.GET['title']).order_by('title')
@@ -87,6 +91,7 @@ def exhibitSearch(request):
         exhibits = Exhibit.objects.all().order_by('title')
         return render(request, 'exhibits/exhibitSearch.html', {'searchTerm': '', 'exhibits': exhibits})
 
+@cache_by_session_state
 def exhibitDirectory(request, category='search'):
     if category in list(category for (category, display) in Theme.CATEGORY_CHOICES):
         themes = Theme.objects.filter(category=category).order_by('sort_title')
@@ -112,17 +117,20 @@ def exhibitDirectory(request, category='search'):
 
     return render(request, 'exhibits/exhibitDirectory.html', {'themes': [{'', exhibits}], 'categories': Theme.CATEGORY_CHOICES, 'selected': category})
 
+@cache_by_session_state
 def themeDirectory(request):
     jarda = Theme.objects.get(slug='jarda')
     california_cultures = Theme.objects.filter(title__icontains='California Cultures').order_by('title')
     california_history = Theme.objects.exclude(title__icontains='California Cultures').exclude(slug='jarda')
     return render(request, 'exhibits/themeDirectory.html', {'jarda': jarda, 'california_cultures': california_cultures, 'california_history': california_history})
 
+@cache_by_session_state
 def lessonPlanDirectory(request):
     lessonPlans = LessonPlan.objects.all()
     historicalEssays = HistoricalEssay.objects.all()
     return render(request, 'exhibits/for-teachers.html', {'lessonPlans': lessonPlans, 'historicalEssays': historicalEssays})
 
+@cache_by_session_state
 def itemView(request, exhibit_id, item_id):
     fromExhibitPage = request.META.get("HTTP_X_EXHIBIT_ITEM")
     exhibitItem = get_object_or_404(ExhibitItem, item_id=item_id, exhibit=exhibit_id)
@@ -148,6 +156,7 @@ def itemView(request, exhibit_id, item_id):
         return render(request, 'exhibits/itemView.html',
         {'exhibit': exhibit, 'q': '', 'exhibitItems': exhibitItems, 'relatedExhibitsByTheme': exhibitListing, 'exhibitItem': exhibitItem, 'nextItem': nextItem, 'prevItem': prevItem})
 
+@cache_by_session_state
 def lessonPlanItemView(request, lesson_id, item_id):
     fromLessonPage = request.META.get("HTTP_X_EXHIBIT_ITEM")
     exhibitItem = get_object_or_404(ExhibitItem, item_id=item_id, lesson_plan=lesson_id)
@@ -168,6 +177,7 @@ def lessonPlanItemView(request, lesson_id, item_id):
         return render(request, 'exhibits/lessonItemView.html',
         {'lessonPlan': lesson, 'q': '', 'exhibitItems': exhibitItems, 'exhibitItem': exhibitItem, 'nextItem': nextItem, 'prevItem': prevItem})
 
+@cache_by_session_state
 def exhibitView(request, exhibit_id, exhibit_slug):
     fromExhibitPage = request.META.get("HTTP_X_EXHIBIT_ITEM")
     if fromExhibitPage and settings.CALISPHERE:
@@ -187,6 +197,7 @@ def exhibitView(request, exhibit_id, exhibit_slug):
     return render(request, 'exhibits/exhibitView.html',
     {'exhibit': exhibit, 'q': '', 'exhibitItems': exhibitItems, 'relatedExhibitsByTheme': exhibitListing})
 
+@cache_by_session_state
 def essayView(request, essay_id, essay_slug):
     essay = get_object_or_404(HistoricalEssay, pk=essay_id)
     if essay_slug != essay.slug:
@@ -194,6 +205,7 @@ def essayView(request, essay_id, essay_slug):
 
     return render(request, 'exhibits/essayView.html', {'essay': essay, 'q': ''})
 
+@cache_by_session_state
 def themeView(request, theme_id, theme_slug):
     theme = get_object_or_404(Theme, pk=theme_id)
     if theme_slug != theme.slug:
@@ -202,6 +214,7 @@ def themeView(request, theme_id, theme_slug):
     exhibitListing = theme.published_exhibits().all().order_by('order')
     return render(request, 'exhibits/themeView.html', {'theme': theme, 'relatedExhibits': exhibitListing})
 
+@cache_by_session_state
 def lessonPlanView(request, lesson_id, lesson_slug):
     fromLessonPage = request.META.get("HTTP_X_EXHIBIT_ITEM")
     if fromLessonPage and settings.CALISPHERE:
@@ -219,6 +232,7 @@ def lessonPlanView(request, lesson_id, lesson_slug):
     
     return render(request, 'exhibits/lessonPlanView.html', {'lessonPlan': lesson, 'q': '', 'exhibitItems': exhibitItems, 'relatedThemes': relatedThemes})
 
+@cache_by_session_state
 def exhibitItemView(request):
     response = {'exhibits': []}
     exhibits = Exhibit.objects.all()
@@ -280,7 +294,7 @@ def exhibitItemView(request):
 
     return JsonResponse(response)
 
-
+@cache_by_session_state
 def item_health(request): 
     page_size = 100
     exhibit_item_ids = ExhibitItem.objects.values_list('item_id', flat=True)


### PR DESCRIPTION
Exhibitapp depends on our index in a few different ways:
- if an image is not defined for a given exhibitapp model's image field, the exhibitapp is configured to fallback to a `reference_item_md5` pulled from a record in the index
- exhibit item metadata is pulled from the index

It strikes me as really clunky that we essentially copy the following files from the public_interface application:
- cache_retry.py
- es_cache_retry.py
- utils.py (which actually includes public_interface's decorators.py)

We do this in order to provide these modules to the registry's deployment of exhibitapp. When the exhibitapp is deployed in Calisphere's context, though, we preference Calisphere's version of these modules - basically to protect Calisphere against cases when these modules fall out of sync. 