### PR TITLE
Upgrade to Django3.2

### DIFF
--- a/exhibits/apps.py
+++ b/exhibits/apps.py
@@ -5,3 +5,4 @@ from django.apps import AppConfig
 
 class ExhibitsConfig(AppConfig):
     name = 'exhibits'
+    default_auto_field = 'django.db.models.AutoField'

--- a/exhibits/cache_retry.py
+++ b/exhibits/cache_retry.py
@@ -1,8 +1,6 @@
 """ logic for cache / retry for solr and JSON from registry
 """
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 from django.core.cache import cache
 from django.conf import settings

--- a/exhibits/models.py
+++ b/exhibits/models.py
@@ -6,7 +6,6 @@ import re
 from django.contrib.auth.models import User
 from django.db import models
 from django.urls import reverse
-from django.utils.encoding import python_2_unicode_compatible
 from django.conf import settings
 from exhibits.custom_fields import HeroField
 from exhibits.md5s3stash import md5s3stash
@@ -79,7 +78,6 @@ class PublishedExhibitManager(models.Manager):
         else:
             return super(PublishedExhibitManager, self).get_queryset().filter(publish=True)
 
-@python_2_unicode_compatible
 class Exhibit(models.Model):
     title = models.CharField(max_length=512)
     slug = models.SlugField(max_length=255, unique=True)
@@ -200,7 +198,6 @@ class PublishedHistoricalEssayManager(models.Manager):
         else:
             return super(PublishedHistoricalEssayManager, self).get_queryset().filter(publish=True)
 
-@python_2_unicode_compatible
 class HistoricalEssay(models.Model):
     title = models.CharField(max_length=200)
     slug = models.SlugField(max_length=255, unique=True)
@@ -300,7 +297,6 @@ class PublishedLessonPlanManager(models.Manager):
         else:
             return super(PublishedLessonPlanManager, self).get_queryset().filter(publish=True)
 
-@python_2_unicode_compatible
 class LessonPlan(models.Model):
     title = models.CharField(max_length=200)
     sub_title = models.CharField(max_length=512, blank=True)
@@ -391,7 +387,6 @@ class PublishedThemeManager(models.Manager):
         else:
             return super(PublishedThemeManager, self).get_queryset().filter(publish=True)
 
-@python_2_unicode_compatible
 class Theme(models.Model):
     title = models.CharField(max_length=200)
     sort_title = models.CharField(blank=True, max_length=200, verbose_name='Sortable Title')
@@ -503,7 +498,6 @@ class PublishedExhibitItemManager(models.Manager):
         else:
             return super(PublishedExhibitItemManager, self).get_queryset().filter(publish=True)
 
-@python_2_unicode_compatible
 class ExhibitItem(models.Model):
     item_id = models.CharField(max_length=200)
 
@@ -586,7 +580,6 @@ class ExhibitItem(models.Model):
                     super(ExhibitItem, self).save(update_fields=[s3field])
                     self._meta.get_field(s3field).upload_to = upload_to
 
-@python_2_unicode_compatible
 class NotesItem(models.Model):
     title = models.CharField(max_length=200)
     exhibit = models.ForeignKey(Exhibit, on_delete=models.CASCADE)
@@ -621,7 +614,6 @@ class LessonPlanExhibit(models.Model):
         ordering = ['order']
 
 # Exhibits ordered within Themes
-@python_2_unicode_compatible
 class ExhibitTheme(models.Model):
     exhibit = models.ForeignKey(Exhibit, on_delete=models.CASCADE)
     theme = models.ForeignKey(Theme, on_delete=models.CASCADE)

--- a/exhibits/templatetags/markdown_filter.py
+++ b/exhibits/templatetags/markdown_filter.py
@@ -6,10 +6,14 @@ from markdown.extensions import Extension
 # per notes in the release docs for version 2.5, used an EscapeHTML 
 # extension to replace safe_mode="escape" (deprecated)
 
+# https://python-markdown.github.io/changelog/#safe_mode-and-html_replacement_text-keywords-deprecated
+# https://python-markdown.github.io/changelog/#md_globals-keyword-deprecated-from-extension-api
+# https://python-markdown.github.io/changelog/#previously-deprecated-objects-have-been-removed
+
 class EscapeHtml(Extension):
-	def extendMarkdown(self, md, md_globals):
-		del md.preprocessors['html_block']
-		del md.inlinePatterns['html']
+	def extendMarkdown(self, md):
+		md.preprocessors.deregister('html_block')
+		md.inlinePatterns.deregister('html')
 
 register = Library()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 Django>=1.11.22,<3.3.*
-future==0.18.3
 requests==2.31.0
 markdown==3.4.4
 boto3==1.33.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-Django>=1.11.22,==1.11.*
-future==0.16.0
-requests==2.21.0
-markdown==2.6.8
-boto3==1.12.25
-pilbox==1.3.4
-Pillow==5.2.0
-python-magic==0.4.15
+Django>=1.11.22,<=3.2.*
+future==0.18.3
+requests==2.31.0
+markdown==3.4.4
+boto3==1.33.13
+Pillow==9.5.0
+python-magic==0.4.27
+retrying==1.3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-Django>=1.11.22,<3.3.*
+Django>=3.2.23,==3.2.*
 requests==2.31.0
-markdown==3.4.4
-boto3==1.33.13
-Pillow==9.5.0
+markdown==3.6
+boto3==1.34.84
+Pillow==10.3.0
 python-magic==0.4.27
 retrying==1.3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>=1.11.22,<=3.2.*
+Django>=1.11.22,<3.3.*
 future==0.18.3
 requests==2.31.0
 markdown==3.4.4


### PR DESCRIPTION
[This PR is paired with https://github.com/ucldc/public_interface/pull/316]

This PR:
- Upgraded `requests`, `markdown`, `boto3`, `Pillow`, `python-magic` packages (none of these required significant changes to the codebase except the `markdown` upgrade). 
- Removed python2 to python3 compatibility layer `future 0.16.0`
- Removed `pilbox` - we aren't actually serving any images from exhibitapp, and we aren't installing `md5s3stash` anymore, so we don't see errors regarding this missing dependency of `md5s3stash`

It's worth noting that in future versions of Django, the default primary key type is a `BigAutoField` instead of the `AutoField` used in Django versions up to and including Django 3.2. Django3.2 introduced the capability to configure the default primary key field type at the project level in `settings.py` or at the app level in AppConfig, in order to protect against this future. I've chosen to [configure our ExhibitApp to continue using AutoField](https://github.com/ucldc/exhibitapp/pull/31/commits/3c020f984e0de4d2f8dfef8feeb87b72903effdb), rather than migrating our existing ExhibitApp databases to use a BigAutoField as a primary key. Since this will be the default in future Django, we may want to consider migrating at some point, but as of Django3.2 there was not a clear migration path or utility. 

The first three commits of this PR are already deployed to the collection registry, where we are already running the exhibitapp in Django3.2: https://github.com/ucldc/exhibitapp/commit/07703bedccf019194972a65ac77cd11bc26ddcb0, https://github.com/ucldc/exhibitapp/commit/fff90f0dbc78d07c286b52c4d2e923884873b72c, https://github.com/ucldc/exhibitapp/commit/0da7f3191eae62b50c406fbcf83bca652ea0feb9

Merging this commit will auto-deploy it to calisphere-test and calisphere-stage, but we will also need to deploy this to registry-stg, manually as well. Then Registry and Calisphere will all be on the same exhibitapp. 